### PR TITLE
Allow update checks definitions

### DIFF
--- a/check.go
+++ b/check.go
@@ -244,13 +244,14 @@ func (c *CheckRunner) reapServicesInternal() {
 		}
 
 		timeout := check.Definition.DeregisterCriticalServiceAfter.Duration()
-		if timeout > 0 && timeout > time.Since(criticalTime) {
+		if timeout > 0 && timeout < time.Since(criticalTime) {
 			c.client.Catalog().Deregister(&api.CatalogDeregistration{
 				Node:      check.Node,
 				ServiceID: serviceID,
 			}, nil)
-			c.logger.Printf("[INFO] agent: Check %q for service %q has been critical for too long; deregistered service",
-				checkID, serviceID)
+			c.logger.Printf("[INFO] agent: Check %q for service %q has been critical for too long (%q - %q); deregistered service",
+				checkID, serviceID,
+				timeout, time.Since(criticalTime))
 			reaped[serviceID] = true
 		}
 	}

--- a/check.go
+++ b/check.go
@@ -94,10 +94,10 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 				if data, ok := c.checksHTTP[checkHash]; ok && data.HTTP == http.HTTP &&
 					reflect.DeepEqual(data.Header, http.Header) && data.Method == http.Method &&
 					data.TLSSkipVerify == http.TLSSkipVerify && data.Interval == http.Interval &&
-					data.Timeout == http.Timeout {
+					data.Timeout == http.Timeout && c.checks[checkHash].Definition.DeregisterCriticalServiceAfter == definition.DeregisterCriticalServiceAfter {
 					continue
 				}
-				c.logger.Printf("[INFO] Update HTTP check %q, %v, %v", checkHash)
+				c.logger.Printf("[INFO] Update HTTP check %q", checkHash)
 				if c.checks[checkHash].Definition.HTTP != "" {
 					httpCheck := c.checksHTTP[checkHash]
 					httpCheck.Stop()
@@ -126,10 +126,10 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 			if _, ok := c.checks[checkHash]; ok {
 				if data, ok := c.checksTCP[checkHash]; ok &&
 					data.TCP == tcp.TCP && data.Interval == tcp.Interval &&
-					data.Timeout == tcp.Timeout {
+					data.Timeout == tcp.Timeout && c.checks[checkHash].Definition.DeregisterCriticalServiceAfter == definition.DeregisterCriticalServiceAfter {
 					continue
 				}
-				c.logger.Printf("[INFO] Update TCP check %q, %v, %v", checkHash, tcp, c.checksTCP[checkHash])
+				c.logger.Printf("[INFO] Update TCP check %q", checkHash)
 				if c.checks[checkHash].Definition.TCP != "" {
 					tcpCheck := c.checksTCP[checkHash]
 					tcpCheck.Stop()

--- a/check.go
+++ b/check.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -74,9 +75,6 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 
 		checkHash := checkHash(check)
 		found[checkHash] = struct{}{}
-		if _, ok := c.checks[checkHash]; ok {
-			continue
-		}
 
 		definition := check.Definition
 		if definition.HTTP != "" {
@@ -92,6 +90,27 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 				Logger:        c.logger,
 			}
 
+			if _, ok := c.checks[checkHash]; ok {
+				if data, ok := c.checksHTTP[checkHash]; ok && data.HTTP == http.HTTP &&
+					reflect.DeepEqual(data.Header, http.Header) && data.Method == http.Method &&
+					data.TLSSkipVerify == http.TLSSkipVerify && data.Interval == http.Interval &&
+					data.Timeout == http.Timeout {
+					continue
+				}
+				c.logger.Printf("[INFO] Update HTTP check %q, %v, %v", checkHash)
+				if c.checks[checkHash].Definition.HTTP != "" {
+					httpCheck := c.checksHTTP[checkHash]
+					httpCheck.Stop()
+				} else {
+					if _, ok := c.checksTCP[checkHash]; !ok {
+						c.logger.Printf("[WARN] Inconsistency check %q - is not TCP and HTTP", checkHash)
+						continue
+					}
+					tcpCheck := c.checksTCP[checkHash]
+					tcpCheck.Stop()
+					delete(c.checksTCP, checkHash)
+				}
+			}
 			http.Start()
 			c.checksHTTP[checkHash] = http
 		} else if definition.TCP != "" {
@@ -104,6 +123,26 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 				Logger:   c.logger,
 			}
 
+			if _, ok := c.checks[checkHash]; ok {
+				if data, ok := c.checksTCP[checkHash]; ok &&
+					data.TCP == tcp.TCP && data.Interval == tcp.Interval &&
+					data.Timeout == tcp.Timeout {
+					continue
+				}
+				c.logger.Printf("[INFO] Update TCP check %q, %v, %v", checkHash, tcp, c.checksTCP[checkHash])
+				if c.checks[checkHash].Definition.TCP != "" {
+					tcpCheck := c.checksTCP[checkHash]
+					tcpCheck.Stop()
+				} else {
+					if _, ok := c.checksHTTP[checkHash]; !ok {
+						c.logger.Printf("[WARN] Inconsistency check %q - is not TCP and HTTP", checkHash)
+						continue
+					}
+					httpCheck := c.checksHTTP[checkHash]
+					httpCheck.Stop()
+					delete(c.checksHTTP, checkHash)
+				}
+			}
 			tcp.Start()
 			c.checksTCP[checkHash] = tcp
 		} else {


### PR DESCRIPTION
There is no update service definition on the fly. I've added possibility of this one. After update service check definition - check will reregister