### PR TITLE
Add Dockerfiles for docker-based releases

### DIFF
--- a/build-support/docker/Release.dockerfile
+++ b/build-support/docker/Release.dockerfile
@@ -1,0 +1,62 @@
+# This Dockerfile creates a production release image for the project. This
+# downloads the release from releases.hashicorp.com and therefore requires that
+# the release is published before building the Docker image.
+#
+# We don't rebuild the software because we want the exact checksums and
+# binary signatures to match the software and our builds aren't fully
+# reproducible currently.
+FROM alpine:3.8
+
+# NAME and VERSION are the name of the software in releases.hashicorp.com
+# and the version to download. Example: NAME=consul VERSION=1.2.3.
+ARG NAME
+ARG VERSION
+
+# Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
+ENV NAME=$NAME
+ENV VERSION=$VERSION
+
+# This is the location of the releases.
+ENV HASHICORP_RELEASES=https://releases.hashicorp.com
+
+# Create a non-root user to run the software.
+RUN addgroup ${NAME} && \
+    adduser -S -G ${NAME} ${NAME}
+
+# Set up certificates, base tools, and software.
+RUN set -eux && \
+    apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils && \
+    BUILD_GPGKEY=91A6E7F85D05C65630BEF18951852D87348FFC4C; \
+    found=''; \
+    for server in \
+        hkp://p80.pool.sks-keyservers.net:80 \
+        hkp://keyserver.ubuntu.com:80 \
+        hkp://pgp.mit.edu:80 \
+    ; do \
+        echo "Fetching GPG key $BUILD_GPGKEY from $server"; \
+        gpg --keyserver "$server" --recv-keys "$BUILD_GPGKEY" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch GPG key $BUILD_GPGKEY" && exit 1; \
+    mkdir -p /tmp/build && \
+    cd /tmp/build && \
+    apkArch="$(apk --print-arch)" && \
+    case "${apkArch}" in \
+        aarch64) ARCH='arm64' ;; \
+        armhf) ARCH='arm' ;; \
+        x86) ARCH='386' ;; \
+        x86_64) ARCH='amd64' ;; \
+        *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/${NAME}/${VERSION}/)" && exit 1 ;; \
+    esac && \
+    wget ${HASHICORP_RELEASES}/${NAME}/${VERSION}/${NAME}_${VERSION}_linux_${ARCH}.zip && \
+    wget ${HASHICORP_RELEASES}/${NAME}/${VERSION}/${NAME}_${VERSION}_SHA256SUMS && \
+    wget ${HASHICORP_RELEASES}/${NAME}/${VERSION}/${NAME}_${VERSION}_SHA256SUMS.sig && \
+    gpg --batch --verify ${NAME}_${VERSION}_SHA256SUMS.sig ${NAME}_${VERSION}_SHA256SUMS && \
+    grep ${NAME}_${VERSION}_linux_${ARCH}.zip ${NAME}_${VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /bin ${NAME}_${VERSION}_linux_${ARCH}.zip && \
+    cd /tmp && \
+    rm -rf /tmp/build && \
+    apk del gnupg openssl && \
+    rm -rf /root/.gnupg
+
+USER ${NAME}
+CMD /bin/${NAME}

--- a/build-support/docker/hooks/build
+++ b/build-support/docker/hooks/build
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# DOCKER_REPO is like "index.docker.io/foo/bar". The bashism below extracts
+# the string after the last "/". For VERSION, we extract the string after the
+# first "v" (so v1.2.3 turns into 1.2.3).
+NAME=${DOCKER_REPO##*/}
+VERSION=${SOURCE_BRANCH#*v}
+
+# If the version is equal to the original value, then we have an invalid
+# branch name. In this case, we trigger a Dev build.
+if [ "${VERSION}" = "${SOURCE_BRANCH}" ]; then
+    echo "=> Non-tag trigger. Ignoring."
+    exit 1
+fi
+
+# We have a NAME and VERSION set, so we build a release image.
+echo "=> Building Docker image for ${NAME}:${VERSION}"
+docker build \
+    -t ${DOCKER_REPO}:${VERSION} \
+    -f $(basename "${BUILD_PATH}") \
+    --build-arg "NAME=${NAME}" \
+    --build-arg "VERSION=${VERSION}" \
+    .


### PR DESCRIPTION
This just copies what we have from consul-k8s.

I put it in the `build-support` folder even though that didn't exist because I figure we might expand that with other Consul stuff to add more release automation. Maybe not. Up to you.