### PR TITLE
Run all external node pings in parallel

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -40,6 +40,9 @@ type Agent struct {
 	shutdownCh chan struct{}
 	shutdown   bool
 
+	inflightPings map[string]struct{}
+	inflightLock  sync.Mutex
+
 	// Custom func to hook into for testing.
 	watchedNodeFunc func(map[string]bool, []*api.Node)
 }
@@ -62,11 +65,12 @@ func NewAgent(config *Config, logger *log.Logger) (*Agent, error) {
 	}
 
 	agent := Agent{
-		config:     config,
-		client:     client,
-		id:         id,
-		logger:     logger,
-		shutdownCh: make(chan struct{}),
+		config:        config,
+		client:        client,
+		id:            id,
+		logger:        logger,
+		shutdownCh:    make(chan struct{}),
+		inflightPings: make(map[string]struct{}),
 	}
 
 	logger.Printf("[INFO] Connecting to Consul on %s...", clientConf.Address)

--- a/coordinate.go
+++ b/coordinate.go
@@ -43,7 +43,7 @@ func (a *Agent) updateCoords(nodeCh <-chan []*api.Node) {
 		case newNodes := <-nodeCh:
 			if len(newNodes) != len(nodes) {
 				ticker.Stop()
-				ticker = a.nodeTicker(len(nodes))
+				ticker = a.nodeTicker(len(newNodes))
 				a.logger.Printf("[INFO] Now running probes for %d external nodes", len(newNodes))
 			}
 			nodes = newNodes
@@ -127,6 +127,7 @@ func (a *Agent) nodeTicker(numNodes int) *time.Ticker {
 	if numNodes > 0 {
 		waitTime = a.config.CoordinateUpdateInterval / time.Duration(numNodes)
 	}
+	a.logger.Printf("[DEBUG] Now waiting %s between node pings", waitTime.String())
 	return time.NewTicker(waitTime)
 }
 


### PR DESCRIPTION
This PR changes the node pings to happen fully parallel to one another, to fix an issue where they were delayed with large numbers of nodes by things like ping timeouts and slow responses from the local Consul agent.