### PR TITLE
Default check intervals to 30s

### DIFF
--- a/check.go
+++ b/check.go
@@ -18,6 +18,11 @@ import (
 
 const externalCheckName = "externalNodeHealth"
 
+var (
+	// defaultInterval is the check interval to use if one is not set.
+	defaultInterval = 30 * time.Second
+)
+
 type CheckRunner struct {
 	sync.RWMutex
 
@@ -79,6 +84,9 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 		found[checkHash] = struct{}{}
 
 		definition := check.Definition
+		if definition.IntervalDuration == 0 {
+			definition.IntervalDuration = defaultInterval
+		}
 		if definition.HTTP != "" {
 			http := &consulchecks.CheckHTTP{
 				Notify:        c,


### PR DESCRIPTION
Currently if consul-esm gets back an empty check interval from the api, it'll default to 0 and cause the check to run in a busy loop. This could happen with the duration field bug in the txn check api: https://github.com/hashicorp/consul/issues/5477.