### PR TITLE
Update CheckRunner if status of known catalog check differs

### DIFF
--- a/check.go
+++ b/check.go
@@ -93,10 +93,11 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 			}
 
 			if _, ok := c.checks[checkHash]; ok {
-				if data, ok := c.checksHTTP[checkHash]; ok && data.HTTP == http.HTTP &&
-					reflect.DeepEqual(data.Header, http.Header) && data.Method == http.Method &&
-					data.TLSSkipVerify == http.TLSSkipVerify && data.Interval == http.Interval &&
-					data.Timeout == http.Timeout && c.checks[checkHash].Definition.DeregisterCriticalServiceAfter == definition.DeregisterCriticalServiceAfter {
+				if data, ok := c.checksHTTP[checkHash]; ok &&
+					c.checks[checkHash].Status == check.Status &&
+					data.HTTP == http.HTTP && reflect.DeepEqual(data.Header, http.Header) && data.Method == http.Method &&
+					data.TLSSkipVerify == http.TLSSkipVerify && data.Interval == http.Interval && data.Timeout == http.Timeout &&
+					c.checks[checkHash].Definition.DeregisterCriticalServiceAfter == definition.DeregisterCriticalServiceAfter {
 					continue
 				}
 				c.logger.Printf("[INFO] Updating HTTP check %q", checkHash)
@@ -127,6 +128,7 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 
 			if _, ok := c.checks[checkHash]; ok {
 				if data, ok := c.checksTCP[checkHash]; ok &&
+					c.checks[checkHash].Status == check.Status &&
 					data.TCP == tcp.TCP && data.Interval == tcp.Interval &&
 					data.Timeout == tcp.Timeout && c.checks[checkHash].Definition.DeregisterCriticalServiceAfter == definition.DeregisterCriticalServiceAfter {
 					continue

--- a/check_test.go
+++ b/check_test.go
@@ -62,7 +62,30 @@ func TestCheck_HTTP(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		checks, _, err = client.Health().State(api.HealthAny, &api.QueryOptions{NodeMeta: nodeMeta})
 		if len(checks) != 1 || checks[0].Status != api.HealthPassing {
-			r.Fatalf("bad: %v", checks[0])
+			r.Fatalf("expected: %v, got: %v", api.HealthPassing, checks[0].Status)
+		}
+	})
+
+	// Re-register the check as critical initially
+	// The catalog should eventually show the check as passing
+	nodeRegistration.SkipNodeUpdate = true
+	nodeRegistration.Check.Status = api.HealthCritical
+	_, err = client.Catalog().Register(nodeRegistration, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks, _, err = client.Health().State(api.HealthAny, &api.QueryOptions{NodeMeta: nodeMeta})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner.UpdateChecks(checks)
+
+	retry.Run(t, func(r *retry.R) {
+		checks, _, err = client.Health().State(api.HealthAny, &api.QueryOptions{NodeMeta: nodeMeta})
+		if len(checks) != 1 || checks[0].Status != api.HealthPassing {
+			r.Fatalf("expected: %v, got: %v", api.HealthPassing, checks[0].Status)
 		}
 	})
 
@@ -85,7 +108,7 @@ func TestCheck_HTTP(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		checks, _, err = client.Health().State(api.HealthAny, &api.QueryOptions{NodeMeta: nodeMeta})
 		if len(checks) != 1 || checks[0].Status != api.HealthCritical {
-			r.Fatalf("bad: %v", checks[0])
+			r.Fatalf("expected: %v, got: %v", api.HealthCritical, checks[0].Status)
 		}
 	})
 }
@@ -144,7 +167,34 @@ func TestCheck_TCP(t *testing.T) {
 			r.Fatal(err)
 		}
 		if len(checks) != 1 || checks[0].Status != api.HealthPassing {
-			r.Fatalf("bad: %v", checks[0])
+			r.Fatalf("expected: %v, got: %v", api.HealthPassing, checks[0].Status)
+		}
+	})
+
+	// Re-register the check as critical initially
+	// The catalog should eventually show the check as passing
+	nodeRegistration.SkipNodeUpdate = true
+	nodeRegistration.Check.Status = api.HealthCritical
+	_, err = client.Catalog().Register(nodeRegistration, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks, _, err = client.Health().State(api.HealthAny, &api.QueryOptions{NodeMeta: nodeMeta})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner.UpdateChecks(checks)
+
+	// Make sure the health has been updated to passing
+	retry.Run(t, func(r *retry.R) {
+		checks, _, err = client.Health().State(api.HealthAny, &api.QueryOptions{NodeMeta: nodeMeta})
+		if err != nil {
+			r.Fatal(err)
+		}
+		if len(checks) != 1 || checks[0].Status != api.HealthPassing {
+			r.Fatalf("expected: %v, got: %v", api.HealthPassing, checks[0].Status)
 		}
 	})
 
@@ -167,7 +217,7 @@ func TestCheck_TCP(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		checks, _, err = client.Health().State(api.HealthAny, &api.QueryOptions{NodeMeta: nodeMeta})
 		if len(checks) != 1 || checks[0].Status != api.HealthCritical {
-			r.Fatalf("bad: %v", checks[0])
+			r.Fatalf("expected: %v, got: %v", api.HealthCritical, checks[0].Status)
 		}
 	})
 }


### PR DESCRIPTION
Fixes: #36 

Currently there is the potential for the catalog to not be updated when a health probe disagrees.

In the issue reported, the catalog shows a check as critical while the CheckRunner and probe see it as passing. Because the CheckRunner and probe agreed, the passing status was not synced back to the catalog. 

In this PR there is an update to UpdateChecks so that if a known check is seen in the catalog with a new status, it is updated in the CheckRunner.