### PR TITLE
Make ESM Instance ID Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ enable_syslog = false
 // The syslog facility to use, if enabled.
 syslog_facility = ""
 
+// The unique id for this agent to use when registering itself with Consul.
+// If unconfigured, a UUID will be generated for the instance id.
+// Note: do not reuse the same instance id value for other agents. This id
+// must be unique to disambiguate different instances on the same host.
+// Failure to maintain uniqueness will result in an already-exists error.
+instance_id = ""
+
 // The service name for this agent to use when registering itself with Consul.
 consul_service = "consul-esm"
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -12,7 +12,10 @@ import (
 
 func testAgent(t *testing.T, cb func(*Config)) *Agent {
 	logger := log.New(LOGOUT, "", log.LstdFlags)
-	conf := DefaultConfig()
+	conf, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
 	conf.CoordinateUpdateInterval = 200 * time.Millisecond
 	if cb != nil {
 		cb(conf)
@@ -167,10 +170,15 @@ func TestAgent_shouldUpdateNodeStatus(t *testing.T) {
 		},
 	}
 
+	conf, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 
 		agent := Agent{
-			config:            DefaultConfig(),
+			config:            conf,
 			knownNodeStatuses: make(map[string]lastKnownStatus),
 		}
 
@@ -240,5 +248,117 @@ func TestAgent_VerifyConsulCompatibility(t *testing.T) {
 	err = agent.VerifyConsulCompatibility()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestAgent_uniqueInstanceID(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewTestServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	// Register first ESM instance
+	agent1 := testAgent(t, func(c *Config) {
+		c.HTTPAddr = s.HTTPAddr
+		c.InstanceID = "unique-instance-id-1"
+	})
+	defer agent1.Shutdown()
+
+	// Make sure the first ESM service is registered
+	retry.Run(t, func(r *retry.R) {
+		services, _, err := agent1.client.Catalog().Service(agent1.config.Service, "", nil)
+		if err != nil {
+			r.Fatal(err)
+		}
+		if len(services) != 1 {
+			r.Fatalf("1 service should be registered: %v", services)
+		}
+		if got, want := services[0].ServiceID, agent1.serviceID(); got != want {
+			r.Fatalf("got service id %q, want %q", got, want)
+		}
+	})
+
+	// Register second ESM instance
+	agent2 := testAgent(t, func(c *Config) {
+		c.HTTPAddr = s.HTTPAddr
+		c.InstanceID = "unique-instance-id-2"
+	})
+	defer agent2.Shutdown()
+
+	// Make sure second ESM service is registered
+	retry.Run(t, func(r *retry.R) {
+		services, _, err := agent2.client.Catalog().Service(agent2.config.Service, "", nil)
+		if err != nil {
+			r.Fatal(err)
+		}
+		if len(services) != 2 {
+			r.Fatalf("2 service should be registered, got: %v", services)
+		}
+		if got, want := services[1].ServiceID, agent2.serviceID(); got != want {
+			r.Fatalf("got service id %q, want %q", got, want)
+		}
+	})
+}
+
+func TestAgent_notUniqueInstanceIDFails(t *testing.T) {
+	t.Parallel()
+	notUniqueInstanceID := "not-unique-instance-id"
+
+	s, err := NewTestServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	// Register first ESM instance
+	agent := testAgent(t, func(c *Config) {
+		c.HTTPAddr = s.HTTPAddr
+		c.InstanceID = notUniqueInstanceID
+	})
+	defer agent.Shutdown()
+
+	// Make sure the ESM service is registered
+	ensureRegistered := func(r *retry.R) {
+		services, _, err := agent.client.Catalog().Service(agent.config.Service, "", nil)
+		if err != nil {
+			r.Fatal(err)
+		}
+		if len(services) != 1 {
+			r.Fatalf("1 service should be registered: %v", services)
+		}
+		if got, want := services[0].ServiceID, agent.serviceID(); got != want {
+			r.Fatalf("got service id %q, want %q", got, want)
+		}
+	}
+	retry.Run(t, ensureRegistered)
+
+	// Create second ESM service with same instance ID
+	logger := log.New(LOGOUT, "", log.LstdFlags)
+	conf, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	conf.InstanceID = notUniqueInstanceID
+	conf.HTTPAddr = s.HTTPAddr
+
+	duplicateAgent, err := NewAgent(conf, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = duplicateAgent.Run()
+	defer duplicateAgent.Shutdown()
+
+	if err == nil {
+		t.Fatal("Failed to error when registering ESM service with same instance ID")
+	}
+
+	switch e := err.(type) {
+	case *alreadyExistsError:
+	default:
+		t.Fatalf("Unexpected error type. Wanted an alreadyExistsError type. Error: '%v'", e)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -11,6 +11,7 @@ import (
 func TestDecodeMergeConfig(t *testing.T) {
 	raw := bytes.NewBufferString(`
 log_level = "INFO"
+instance_id = "test-instance-id"
 consul_service = "service"
 consul_service_tag = "asdf"
 consul_kv_path = "custom-esm/"
@@ -34,6 +35,7 @@ ping_type = "socket"
 
 	expected := &Config{
 		LogLevel:                 "INFO",
+		InstanceID:               "test-instance-id",
 		Service:                  "service",
 		Tag:                      "asdf",
 		KVPath:                   "custom-esm/",
@@ -90,7 +92,11 @@ func TestValidateConfig(t *testing.T) {
 	for _, tc := range cases {
 		buf := bytes.NewBufferString(tc.raw)
 
-		result := DefaultConfig()
+		result, err := DefaultConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		humanConfig, err := DecodeConfig(buf)
 		if err != nil {
 			t.Fatal(err)

--- a/coordinate_test.go
+++ b/coordinate_test.go
@@ -34,9 +34,14 @@ func TestCoordinate_updateNodeCoordinate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	conf, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	agent := &Agent{
 		client:            client,
-		config:            DefaultConfig(),
+		config:            conf,
 		logger:            log.New(LOGOUT, "", log.LstdFlags),
 		knownNodeStatuses: make(map[string]lastKnownStatus),
 	}
@@ -78,9 +83,14 @@ func TestCoordinate_updateNodeCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	conf, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	agent := &Agent{
 		client:            client,
-		config:            DefaultConfig(),
+		config:            conf,
 		logger:            log.New(LOGOUT, "", log.LstdFlags),
 		knownNodeStatuses: make(map[string]lastKnownStatus),
 	}
@@ -173,9 +183,14 @@ func TestCoordinate_reapFailedNode(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	conf, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	agent := &Agent{
 		client:            client,
-		config:            DefaultConfig(),
+		config:            conf,
 		logger:            log.New(LOGOUT, "", log.LstdFlags),
 		knownNodeStatuses: make(map[string]lastKnownStatus),
 	}

--- a/leader_test.go
+++ b/leader_test.go
@@ -109,7 +109,7 @@ func TestLeader_rebalanceHealthWatches(t *testing.T) {
 	// Register one ESM agent to start.
 	agent1 := testAgent(t, func(c *Config) {
 		c.HTTPAddr = s.HTTPAddr
-		c.id = "agent1"
+		c.InstanceID = "agent1"
 	})
 	defer agent1.Shutdown()
 
@@ -119,7 +119,7 @@ func TestLeader_rebalanceHealthWatches(t *testing.T) {
 	// Add a 2nd ESM agent.
 	agent2 := testAgent(t, func(c *Config) {
 		c.HTTPAddr = s.HTTPAddr
-		c.id = "agent2"
+		c.InstanceID = "agent2"
 	})
 	defer agent2.Shutdown()
 
@@ -130,7 +130,7 @@ func TestLeader_rebalanceHealthWatches(t *testing.T) {
 	// Add a 3rd ESM agent.
 	agent3 := testAgent(t, func(c *Config) {
 		c.HTTPAddr = s.HTTPAddr
-		c.id = "agent3"
+		c.InstanceID = "agent3"
 	})
 	defer agent3.Shutdown()
 
@@ -200,13 +200,13 @@ func TestLeader_divideCoordinates(t *testing.T) {
 	// Register two ESM agents.
 	agent1 := testAgent(t, func(c *Config) {
 		c.HTTPAddr = s.HTTPAddr
-		c.id = "agent1"
+		c.InstanceID = "agent1"
 	})
 	defer agent1.Shutdown()
 
 	agent2 := testAgent(t, func(c *Config) {
 		c.HTTPAddr = s.HTTPAddr
-		c.id = "agent2"
+		c.InstanceID = "agent2"
 	})
 	defer agent2.Shutdown()
 
@@ -316,14 +316,14 @@ func TestLeader_divideHealthChecks(t *testing.T) {
 	// Register two ESM agents.
 	agent1 := testAgent(t, func(c *Config) {
 		c.HTTPAddr = s.HTTPAddr
-		c.id = "agent1"
+		c.InstanceID = "agent1"
 		c.CoordinateUpdateInterval = time.Second
 	})
 	defer agent1.Shutdown()
 
 	agent2 := testAgent(t, func(c *Config) {
 		c.HTTPAddr = s.HTTPAddr
-		c.id = "agent2"
+		c.InstanceID = "agent2"
 		c.CoordinateUpdateInterval = time.Second
 	})
 	defer agent2.Shutdown()


### PR DESCRIPTION
Feature request to allow practitioners to set instance ids in order for ESM
instances to terminate and reregister with Consul with the same id. Ungraceful
terminations currently take 30 minutes to be reaped. Without this feature, when
a new instance starts up, it has a new id and leads to multiple ESM instances
rather than 'replacing' the terminated one.

- Add instance_id in configuration file
- Replace existing `id` used for testing with instance_id
- Add a check to ensure instance_id is unique since we are no longer generating
a unique id on behalf of the practitioner
- Move creating a UUID for id into DefaultConfig() to prevent race condition

Resolves https://github.com/hashicorp/consul-esm/issues/60