### PR TITLE
Update README.md to include documentation on required ACL policy rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ consul_service = "consul-esm"
 
 // The service tag for this agent to use when registering itself with Consul.
 // ESM instances that share a service name/tag combination will have the work
-// of running health checks and pings for any external nodes in the catalog 
+// of running health checks and pings for any external nodes in the catalog
 // divided evenly amongst themselves.
 consul_service_tag = ""
 
@@ -225,6 +225,41 @@ ping_type = "udp"
 
 [HCL]: https://github.com/hashicorp/hcl "HashiCorp Configuration Language (HCL)"
 
+### Consul ACL Policies
+
+With [ACL system][ACL] enabled on Consul agents, a specific ACL policy may be
+required for ESM's token in order for ESM to perform its functions. To narrow
+down the privileges required for ESM the following [ACL policy rules][rules]
+can be used:
+
+```hcl
+agent_prefix "" {
+  policy = "write"
+}
+
+key_prefix "consul-esm/" {
+  policy = "write"
+}
+
+node_prefix "" {
+  policy = "read"
+}
+
+service_prefix "" {
+  policy = "write"
+}
+
+session_prefix "" {
+   policy = "write"
+}
+```
+
+The `key_prefix` rule is set to allow the `consul-esm/` KV prefix, which is
+defined in the config file using the `consul_kv_path` parameter.
+
+[ACL]: https://www.consul.io/docs/acl/acl-system.html "Consul ACL System"
+[rules]: https://www.consul.io/docs/acl/acl-rules "Consul ACL Rules"
+
 ## Contributing
 
 **Note** if you run Linux and see `socket: permission denied` errors with UDP
@@ -255,7 +290,7 @@ $ make dev
 This will compile the `consul-esm` binary into `bin/consul-esm` as
 well as your `$GOPATH` and run the test suite.
 
-If you want to compile a specific binary, run `make XC_OS/XC_ARCH`. 
+If you want to compile a specific binary, run `make XC_OS/XC_ARCH`.
 For example:
 ```
 make darwin/amd64

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ can be used:
 
 ```hcl
 agent_prefix "" {
-  policy = "write"
+  policy = "read"
 }
 
 key_prefix "consul-esm/" {
@@ -242,7 +242,7 @@ key_prefix "consul-esm/" {
 }
 
 node_prefix "" {
-  policy = "read"
+  policy = "write"
 }
 
 service_prefix "" {


### PR DESCRIPTION
We have recently spent quite some time on fighting ACL rules for ESM to allow only necessary permissions for the token ESM uses in Consul. The only piece of documentation found was this resource https://support.hashicorp.com/hc/en-us/articles/360047774114-Consul-Frequently-Used-ACL-Policies#esm. This PR adds missing documentation on required ACL rules for ESM.