### PR TITLE
Add "operator=read" to ACL README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ down the privileges required for ESM the following [ACL policy rules][rules]
 can be used:
 
 ```hcl
+operator = read
+
 agent_prefix "" {
   policy = "read"
 }


### PR DESCRIPTION
ACL for operator:read is necessary for Consul-ESM v0.4.0 due to a new feature that check’s ESM and Consul’s version compatibility on start up: https://github.com/hashicorp/consul-esm/pull/62. This feature makes a request to /operator/autopilot, which needs to be added to the list of necessary ACLs.