### PR TITLE
Introduce fail/pass check thresholds to prevent flapping

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -393,7 +393,8 @@ func (a *Agent) watchHealthChecks(nodeListCh chan map[string]bool) {
 
 	// Start a check runner to track and run the health checks we're responsible for and call
 	// UpdateChecks when we get an update from watchHealthChecks.
-	a.checkRunner = NewCheckRunner(a.logger, a.client, a.config.CheckUpdateInterval, minimumInterval, tlsClientConfig)
+	a.checkRunner = NewCheckRunner(a.logger, a.client, a.config.CheckUpdateInterval, minimumInterval,
+		tlsClientConfig, a.config.PassingThreshold, a.config.CriticalThreshold)
 	go a.checkRunner.reapServices(a.shutdownCh)
 	defer a.checkRunner.Stop()
 

--- a/config_test.go
+++ b/config_test.go
@@ -62,6 +62,8 @@ telemetry {
  	statsd_address = "example.io:8888"
  	statsite_address = "5.6.7.8"
 }
+passing_threshold = 3
+critical_threshold = 2
 `)
 
 	expected := &Config{
@@ -115,6 +117,8 @@ telemetry {
 			StatsdAddr:                         "example.io:8888",
 			StatsiteAddr:                       "5.6.7.8",
 		},
+		PassingThreshold:  3,
+		CriticalThreshold: 2,
 	}
 
 	result := &Config{}


### PR DESCRIPTION
Adds two new config variables, passing_threshold and critical_threshold,
that respectively configure the number of failed checks needed to go
from healthy to critical and the number of passed checks to go from
critical to healthy.

Addresses #50 