### PR TITLE
Reduce log level of noisy messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 
 func handleSignals(logger *log.Logger, signalCh chan os.Signal, agent *Agent) {
 	for sig := range signalCh {
-		logger.Printf("[INFO] Caught signal: %s", sig.String())
+		logger.Printf("[DEBUG] Caught signal: %s", sig.String())
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
 			logger.Printf("[INFO] Shutting down...")


### PR DESCRIPTION
Go 1.14 introduced non-cooperative preemption which causes programs
to receive a log of SIGURGs which they don't have a use for. There
is no need to print them, at least not in INFO level.