### PR TITLE
Improving some flaky tests by tweaking timers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,12 @@ dev:
 
 test:
 	@echo "==> Testing ${NAME}"
-	@go test -timeout=30s -tags="${GOTAGS}" ${TESTARGS} ./...
+	@go test -timeout=60s -tags="${GOTAGS}" ${TESTARGS} ./...
 .PHONY: test
 
 test-race:
 	@echo "==> Testing ${NAME}"
-	@go test -race -timeout=30s -tags="${GOTAGS}" ${TESTARGS} ./...
+	@go test -race -timeout=60s -tags="${GOTAGS}" ${TESTARGS} ./...
 .PHONY: test-race
 
 # dist builds the binaries and then signs and packages them for distribution

--- a/coordinate_test.go
+++ b/coordinate_test.go
@@ -304,6 +304,9 @@ func TestCoordinate_parallelPings(t *testing.T) {
 			if err != nil {
 				r.Fatal(err)
 			}
+			if len(checks) != 1 {
+				r.Fatal("Bad number of checks; wanted 1, got ", len(checks))
+			}
 			expected := &api.HealthCheck{
 				Node:        node,
 				CheckID:     externalCheckName,
@@ -312,9 +315,6 @@ func TestCoordinate_parallelPings(t *testing.T) {
 				Output:      NodeAliveStatus,
 				CreateIndex: checks[0].CreateIndex,
 				ModifyIndex: checks[0].ModifyIndex,
-			}
-			if len(checks) != 1 {
-				r.Fatal("Bad number of checks; wanted 1, got ", len(checks))
 			}
 			if err := compareHealthCheck(checks[0], expected); err != nil {
 				r.Fatal(err)

--- a/main_test.go
+++ b/main_test.go
@@ -24,8 +24,8 @@ func TestMain(m *testing.M) {
 	log.SetOutput(LOGOUT)
 
 	MaxRTT = 500 * time.Millisecond
-	retryTime = 200 * time.Millisecond
-	agentTTL = 100 * time.Millisecond
+	retryTime = 400 * time.Millisecond
+	agentTTL = 300 * time.Millisecond
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
There are few things more annoying than flaky tests. While running the test suite and also on the CI pipeline these failures kept popping up:
```
--- FAIL: TestLeader_divideHealthChecks (7.82s)
    retry.go:121: leader_test.go:25: nil kv entry
        leader_test.go:36: Nodes unequal: want([node1]) got([node1 node2])
```
```
--- FAIL: TestLeader_divideCoordinates (8.62s)
    retry.go:121: leader_test.go:25: nil kv entry
        leader_test.go:42: Probes unequal: want([node1]) got([node1 node2])
```
```
--- FAIL: TestLeader_rebalanceHealthWatches (10.91s)
    retry.go:121: leader_test.go:36: Nodes unequal: want([node1]) got([node1 node3])
        leader_test.go:25: nil kv entry
```
```
--- FAIL: TestAgent_registerServiceAndCheck (9.72s)
    retry.go:121: agent_test.go:111: bad: &{f54b6c89-e0ea-6f47-9071-26abec685c14 node-f54b6c89-e0ea-6f47-9071-26abec685c14 127.0.0.1 dc1 map[lan:127.0.0.1 lan_ipv4:127.0.0.1 wan:127.0.0.1 wan_ipv4:127.0.0.1] map[consul-network-segment:] consul-esm:970fc534-19ec-fc70-fce3-9403abdab117 consul-esm  map[] [test] map[] 0 {1 1} false 0xc00020a2a0 17 [] 17}
        agent_test.go:111: bad: &{f54b6c89-e0ea-6f47-9071-26abec685c14 node-f54b6c89-e0ea-6f47-9071-26abec685c14 127.0.0.1 dc1 map[lan:127.0.0.1 lan_ipv4:127.0.0.1 wan:127.0.0.1 wan_ipv4:127.0.0.1] map[consul-network-segment:] consul-esm:970fc534-19ec-fc70-fce3-9403abdab117 consul-esm  map[] [test] map[] 0 {1 1} false 0xc00020a1c0 17 [] 17}
        agent_test.go:111: bad: &{f54b6c89-e0ea-6f47-9071-26abec685c14 node-f54b6c89-e0ea-6f47-9071-26abec685c14 127.0.0.1 dc1 map[lan:127.0.0.1 lan_ipv4:127.0.0.1 wan:127.0.0.1 wan_ipv4:127.0.0.1] map[consul-network-segment:] consul-esm:970fc534-19ec-fc70-fce3-9403abdab117 consul-esm  map[] [test] map[] 0 {1 1} false 0xc00017c070 17 [] 17}
        agent_test.go:111: bad: &{f54b6c89-e0ea-6f47-9071-26abec685c14 node-f54b6c89-e0ea-6f47-9071-26abec685c14 127.0.0.1 dc1 map[lan:127.0.0.1 lan_ipv4:127.0.0.1 wan:127.0.0.1 wan_ipv4:127.0.0.1] map[consul-network-segment:] consul-esm:970fc534-19ec-fc70-fce3-9403abdab117 consul-esm  map[] [test] map[] 0 {1 1} false 0xc00020a380 17 [] 17}
        agent_test.go:111: bad: &{f54b6c89-e0ea-6f47-9071-26abec685c14 node-f54b6c89-e0ea-6f47-9071-26abec685c14 127.0.0.1 dc1 map[lan:127.0.0.1 lan_ipv4:127.0.0.1 wan:127.0.0.1 wan_ipv4:127.0.0.1] map[consul-network-segment:] consul-esm:970fc534-19ec-fc70-fce3-9403abdab117 consul-esm  map[] [test] map[] 0 {1 1} false 0xc000180070 17 [] 17}
        agent_test.go:111: bad: &{f54b6c89-e0ea-6f47-9071-26abec685c14 node-f54b6c89-e0ea-6f47-9071-26abec685c14 127.0.0.1 dc1 map[lan:127.0.0.1 lan_ipv4:127.0.0.1 wan:127.0.0.1 wan_ipv4:127.0.0.1] map[consul-network-segment:] consul-esm:970fc534-19ec-fc70-fce3-9403abdab117 consul-esm  map[] [test] map[] 0 {1 1} false 0xc000180000 17 [] 17}
        agent_test.go:111: bad: &{f54b6c89-e0ea-6f47-9071-26abec685c14 node-f54b6c89-e0ea-6f47-9071-26abec685c14 127.0.0.1 dc1 map[lan:127.0.0.1 lan_ipv4:127.0.0.1 wan:127.0.0.1 wan_ipv4:127.0.0.1] map[consul-network-segment:] consul-esm:970fc534-19ec-fc70-fce3-9403abdab117 consul-esm  map[] [test] map[] 0 {1 1} false 0xc0001a6000 17 [] 17}
```
```
panic: runtime error: index out of range [0] with length 0

goroutine 4447 [running]:
github.com/hashicorp/consul-esm.TestCoordinate_parallelPings.func2(0xc00039c040)
	/Users/acruz/work/vc/consul-esm/coordinate_test.go:313 +0x346
github.com/hashicorp/consul/sdk/testutil/retry.run.func2(0xc0007800d0, 0xc0008ee4b0, 0xc00039c040)
	/Users/acruz/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.4.0/testutil/retry/retry.go:130 +0x58
created by github.com/hashicorp/consul/sdk/testutil/retry.run
	/Users/acruz/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.4.0/testutil/retry/retry.go:128 +0x120
```

This PR attempts to improve the flaky tests situation.