### PR TITLE
Introduce mTLS support for HTTPS checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,18 @@ key_file = ""
 // variable.
 tls_server_name = ""
 
+// The CA file to use for talking to HTTPS checks.
+https_ca_file = ""
+
+// The path to a directory of CA certs to use for talking to HTTPS checks.
+https_ca_path = ""
+
+// The client cert file to use for talking to HTTPS checks.
+https_cert_file = ""
+
+// The client key file to use for talking to HTTPS checks.
+https_key_file = ""
+
 // The method to use for pinging external nodes. Defaults to "udp" but can
 // also be set to "socket" to use ICMP (which requires root privileges).
 ping_type = "udp"

--- a/check_test.go
+++ b/check_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"log"
 	"testing"
 	"time"
@@ -23,7 +24,7 @@ func TestCheck_HTTP(t *testing.T) {
 	}
 
 	logger := log.New(LOGOUT, "", 0)
-	runner := NewCheckRunner(logger, client, 0, 0)
+	runner := NewCheckRunner(logger, client, 0, 0, &tls.Config{})
 	defer runner.Stop()
 
 	// Register an external node with an initially critical http check.
@@ -125,7 +126,7 @@ func TestCheck_TCP(t *testing.T) {
 	}
 
 	logger := log.New(LOGOUT, "", 0)
-	runner := NewCheckRunner(logger, client, 0, 0)
+	runner := NewCheckRunner(logger, client, 0, 0, &tls.Config{})
 	defer runner.Stop()
 
 	// Register an external node with an initially critical http check
@@ -237,7 +238,7 @@ func TestCheck_MinimumInterval(t *testing.T) {
 
 	logger := log.New(LOGOUT, "", 0)
 	minimumInterval := 2 * time.Second
-	runner := NewCheckRunner(logger, client, 0, minimumInterval)
+	runner := NewCheckRunner(logger, client, 0, minimumInterval, &tls.Config{})
 	defer runner.Stop()
 
 	// Make a check with an interval that is below the minimum required interval

--- a/config.go
+++ b/config.go
@@ -49,6 +49,11 @@ type Config struct {
 	KeyFile       string
 	TLSServerName string
 
+	HTTPSCAFile   string
+	HTTPSCAPath   string
+	HTTPSCertFile string
+	HTTPSKeyFile  string
+
 	PingType string
 
 	DisableCoordinateUpdates bool
@@ -163,6 +168,11 @@ type HumanConfig struct {
 	CertFile      flags.StringValue `mapstructure:"cert_file"`
 	KeyFile       flags.StringValue `mapstructure:"key_file"`
 	TLSServerName flags.StringValue `mapstructure:"tls_server_name"`
+
+	HTTPSCAFile   flags.StringValue `mapstructure:"https_ca_file"`
+	HTTPSCAPath   flags.StringValue `mapstructure:"https_ca_path"`
+	HTTPSCertFile flags.StringValue `mapstructure:"https_cert_file"`
+	HTTPSKeyFile  flags.StringValue `mapstructure:"https_key_file"`
 
 	PingType flags.StringValue `mapstructure:"ping_type"`
 
@@ -396,6 +406,10 @@ func MergeConfig(dst *Config, src *HumanConfig) error {
 	src.CertFile.Merge(&dst.CertFile)
 	src.KeyFile.Merge(&dst.KeyFile)
 	src.TLSServerName.Merge(&dst.TLSServerName)
+	src.HTTPSCAFile.Merge(&dst.HTTPSCAFile)
+	src.HTTPSCAPath.Merge(&dst.HTTPSCAPath)
+	src.HTTPSCertFile.Merge(&dst.HTTPSCertFile)
+	src.HTTPSKeyFile.Merge(&dst.HTTPSKeyFile)
 	src.PingType.Merge(&dst.PingType)
 	src.DisableCoordinateUpdates.Merge(&dst.DisableCoordinateUpdates)
 	if len(src.Telemetry) == 1 {

--- a/config_test.go
+++ b/config_test.go
@@ -32,6 +32,10 @@ ca_path = "ca/"
 cert_file = "cert.pem"
 key_file = "key.pem"
 tls_server_name = "example.io"
+https_ca_file = "CA-cert.pem"
+https_ca_path = "CAPath/"
+https_cert_file = "server-cert.pem"
+https_key_file = "server-key.pem"
 disable_coordinate_updates = true
 ping_type = "socket"
 telemetry {
@@ -80,6 +84,10 @@ telemetry {
 		CertFile:                 "cert.pem",
 		KeyFile:                  "key.pem",
 		TLSServerName:            "example.io",
+		HTTPSCAFile:              "CA-cert.pem",
+		HTTPSCAPath:              "CAPath/",
+		HTTPSCertFile:            "server-cert.pem",
+		HTTPSKeyFile:             "server-key.pem",
 		DisableCoordinateUpdates: true,
 		PingType:                 PingTypeSocket,
 		Telemetry: lib.TelemetryConfig{


### PR DESCRIPTION
Adds https_ca_file, https_ca_path, https_cert_file and https_key_file
config variables to control mTLS usage in HTTPS checks.

Addresses https://github.com/hashicorp/consul-esm/issues/72