### PR TITLE
Don't check the status when syncing a new check

### DIFF
--- a/check.go
+++ b/check.go
@@ -97,7 +97,6 @@ func (c *CheckRunner) updateCheckHTTP(latestCheck *api.HealthCheck, checkHash ty
 	if check, checkExists := c.checks[checkHash]; checkExists {
 		httpCheck, httpCheckExists := c.checksHTTP[checkHash]
 		if httpCheckExists &&
-			check.Status == latestCheck.Status &&
 			httpCheck.HTTP == http.HTTP &&
 			reflect.DeepEqual(httpCheck.Header, http.Header) &&
 			httpCheck.Method == http.Method &&
@@ -147,7 +146,6 @@ func (c *CheckRunner) updateCheckTCP(latestCheck *api.HealthCheck, checkHash typ
 	if check, checkExists := c.checks[checkHash]; checkExists {
 		tcpCheck, tcpCheckExists := c.checksTCP[checkHash]
 		if tcpCheckExists &&
-			check.Status == latestCheck.Status &&
 			tcpCheck.TCP == tcp.TCP &&
 			tcpCheck.Interval == tcp.Interval &&
 			tcpCheck.Timeout == tcp.Timeout &&


### PR DESCRIPTION
The status is managed [outside of the check](https://github.com/hashicorp/consul-esm/blob/master/check.go#L311) itself. 

That means when the status is changing due to a failure or recovery of a service it's status may be different than the one in the catalog. Checking status in the `update*` functions may cause the service to flap during an outage rather then transition cleanly to failing.

This change removes the extra status check in the `update*` functions.