### PR TITLE
Fix goroutine resource leak

### DIFF
--- a/coordinate.go
+++ b/coordinate.go
@@ -400,12 +400,14 @@ func pingNode(addr string, method string) (time.Duration, error) {
 		return 0, fmt.Errorf("invalid ping type %q", method)
 	}
 
+	p.Count = 1
 	p.Timeout = MaxRTT
-	p.OnRecv = func(pkt *ping.Packet) {
-		rtt = pkt.Rtt
-	}
-	p.OnFinish = func(*ping.Statistics) {
-		pingErr = fmt.Errorf("ping to %q timed out", addr)
+	p.OnFinish = func(stats *ping.Statistics) {
+		if stats.PacketsRecv >= p.Count {
+			rtt = stats.MaxRtt
+		} else {
+			pingErr = fmt.Errorf("ping to %q timed out", addr)
+		}
 	}
 	p.Run()
 


### PR DESCRIPTION
During the transiton from go-fastping to go-ping we seem to have picked up a
resource leak. Our debugging shows we are leaking memory, ICMP network sockets and goroutines.

Looking through the code it seems like go-ping must have a Count set otherwise it runs for ever
until stopped.

This means OnRecv is called, but OnFinish is never called for healthy servers, however it also means
the [go-routine here](https://github.com/sparrc/go-ping/blob/master/ping.go#L301) may never return.