### PR TITLE
Add a configurable http metrics interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ https_cert_file = ""
 // The client key file to use for talking to HTTPS checks.
 https_key_file = ""
 
+// Client address to expose API endpoints. Required in order to expose /metrics endpoint for Prometheus. Example: "127.0.0.1:8080"
+client_address = ""
+
 // The method to use for pinging external nodes. Defaults to "udp" but can
 // also be set to "socket" to use ICMP (which requires root privileges).
 ping_type = "udp"

--- a/config.go
+++ b/config.go
@@ -55,6 +55,8 @@ type Config struct {
 	HTTPSCertFile string
 	HTTPSKeyFile  string
 
+	ClientAddress string
+
 	PingType string
 
 	DisableCoordinateUpdates bool
@@ -177,6 +179,8 @@ type HumanConfig struct {
 	HTTPSCAPath   flags.StringValue `mapstructure:"https_ca_path"`
 	HTTPSCertFile flags.StringValue `mapstructure:"https_cert_file"`
 	HTTPSKeyFile  flags.StringValue `mapstructure:"https_key_file"`
+
+	ClientAddress flags.StringValue `mapstructure:"client_address"`
 
 	PingType flags.StringValue `mapstructure:"ping_type"`
 
@@ -466,6 +470,7 @@ func MergeConfig(dst *Config, src *HumanConfig) error {
 	src.HTTPSCAPath.Merge(&dst.HTTPSCAPath)
 	src.HTTPSCertFile.Merge(&dst.HTTPSCertFile)
 	src.HTTPSKeyFile.Merge(&dst.HTTPSKeyFile)
+	src.ClientAddress.Merge(&dst.ClientAddress)
 	src.PingType.Merge(&dst.PingType)
 	src.DisableCoordinateUpdates.Merge(&dst.DisableCoordinateUpdates)
 	if len(src.Telemetry) == 1 {

--- a/config_test.go
+++ b/config_test.go
@@ -37,6 +37,7 @@ https_ca_path = "CAPath/"
 https_cert_file = "server-cert.pem"
 https_key_file = "server-key.pem"
 disable_coordinate_updates = true
+client_address = "127.0.0.1:8080"
 ping_type = "socket"
 telemetry {
 	circonus_api_app = "circonus_api_app"
@@ -91,6 +92,7 @@ critical_threshold = 2
 		HTTPSCertFile:            "server-cert.pem",
 		HTTPSKeyFile:             "server-key.pem",
 		DisableCoordinateUpdates: true,
+		ClientAddress:            "127.0.0.1:8080",
 		PingType:                 PingTypeSocket,
 		Telemetry: lib.TelemetryConfig{
 			CirconusAPIApp:                     "circonus_api_app",

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/prometheus/client_golang v1.4.0
 	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc // indirect


### PR DESCRIPTION
Expose http endpoint so that metrics can be collected. Only used
for Prometheus metrics for now.

Adresses #89 