### PR TITLE
Fix versioning bugs

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -21,8 +21,7 @@ var (
 	GitDescribe string
 
 	// Version is the main version number that is being run at the moment.
-	// Note: our current release process searches this file for "Version ="
-	Version = "0.4.0"
+	// Note: our current release process does a pattern match on this variable.
 	Version = "0.5.0"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""


### PR DESCRIPTION
 - Instead of overwriting the version variable, the variable value should be changed
 - Release process was pattern-matching on the pattern described in the comment instead of the actual version

Context: this bug isn't in the 0.5.0 binary. When staging version changes for the 0.5.0 release, I did not stage all local changes by accident. So while the release commit is incomplete and therefore broken, the full set of changes (deleting version 0.4.0) was present locally and part of the 0.5.0 release. Apologies for the confusion!