### PR TITLE
Adds external-source Metadata when registering consul-esm as a service

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -170,6 +170,12 @@ func (a *Agent) serviceID() string {
 	return fmt.Sprintf("%s:%s", a.config.Service, a.id)
 }
 
+func (a *Agent) serviceMeta() map[string]string {
+	return map[string]string{
+		"external-source": "consul-esm",
+	}
+}
+
 type alreadyExistsError struct {
 	serviceID string
 }
@@ -188,6 +194,7 @@ func (a *Agent) register() error {
 	service := &api.AgentServiceRegistration{
 		ID:   a.serviceID(),
 		Name: a.config.Service,
+		Meta: a.serviceMeta(),
 	}
 	if a.config.Tag != "" {
 		service.Tags = []string{a.config.Tag}

--- a/agent_test.go
+++ b/agent_test.go
@@ -70,6 +70,9 @@ func TestAgent_registerServiceAndCheck(t *testing.T) {
 		if got, want := services[0].ServiceTags, []string{"test"}; !reflect.DeepEqual(got, want) {
 			r.Fatalf("got %q, want %q", got, want)
 		}
+		if got, want := services[0].ServiceMeta, map[string]string{"external-source": "consul-esm"}; !reflect.DeepEqual(got, want) {
+			r.Fatalf("got %q, want %q", got, want)
+		}
 
 		checks, _, err := agent.client.Health().Checks(agent.config.Service, nil)
 		if err != nil {


### PR DESCRIPTION
Primarily used for calling out Consul ESM services in the Consul UI.