### PR TITLE
Change version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ XC_EXCLUDE ?= darwin/arm solaris/386 solaris/arm windows/arm netbsd/arm
 LD_FLAGS ?= \
 	-s \
 	-w \
-	-X ${PROJECT}/version.Name=${NAME} \
-	-X ${PROJECT}/version.GitCommit=${GIT_COMMIT} \
-	-X ${PROJECT}/version.GitDescribe=${GIT_DESCRIBE}
+	-X github.com/hashicorp/consul-esm/version.Name=${NAME} \
+	-X github.com/hashicorp/consul-esm/version.GitCommit=${GIT_COMMIT} \
+	-X github.com/hashicorp/consul-esm/version.GitDescribe=${GIT_DESCRIBE}
 
 # Create a cross-compile target for every os-arch pairing. This will generate
 # a make target for each os/arch like "make linux/amd64" as well as generate a

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ var (
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 
 	consulConstraints version.Constraints
 )
@@ -44,7 +44,7 @@ func init() {
 // GetHumanVersion composes the parts of the version in a way that's suitable
 // for displaying to humans.
 func GetHumanVersion() string {
-	version := Version
+	version := fmt.Sprintf("%s %s",Name, Version)
 	if GitDescribe != "" && VersionPrerelease == "" {
 		version = GitDescribe
 	}
@@ -105,7 +105,7 @@ func CheckConsulVersions(versions []string) error {
 // issue between ESM and Consul servers.
 func NewConsulVersionError(consulVersions []string) error {
 	versions := strings.Join(consulVersions, ", ")
-	return fmt.Errorf(versionErrorTmpl, GetHumanVersion(), versions)
+	return fmt.Errorf(versionErrorTmpl, Version, versions)
 }
 
 const versionErrorTmpl = `

--- a/version/version.go
+++ b/version/version.go
@@ -44,10 +44,7 @@ func init() {
 // GetHumanVersion composes the parts of the version in a way that's suitable
 // for displaying to humans.
 func GetHumanVersion() string {
-	version := fmt.Sprintf("%s %s",Name, Version)
-	if GitDescribe != "" && VersionPrerelease == "" {
-		version = GitDescribe
-	}
+	version := fmt.Sprintf("%s v%s",Name, Version)
 
 	release := VersionPrerelease
 	if GitDescribe == "" && release == "" {
@@ -55,9 +52,9 @@ func GetHumanVersion() string {
 	}
 	if release != "" {
 		version += fmt.Sprintf("-%s", release)
-		if GitCommit != "" {
-			version += fmt.Sprintf(" (%s)", GitCommit)
-		}
+	}
+	if GitCommit != "" {
+		version += fmt.Sprintf(" (%s)", GitCommit)
 	}
 
 	// Strip off any single quotes added by the git information.


### PR DESCRIPTION
Fix https://github.com/hashicorp/consul-esm/issues/87
Now we have the version like this:

> [linux_amd64]$ ./consul-esm -version
> consul-esm 0.5.0-dev (428d995)
> Compatible with Consul versions >= 1.4.1
