### PR TITLE
Add node TCP check with metadata

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ import (
 const (
 	PingTypeUDP    = "udp"
 	PingTypeSocket = "socket"
+	PingTypeTCP    = "tcp:"
 )
 
 type Config struct {

--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ var (
 
 	// Version is the main version number that is being run at the moment.
 	// Note: our current release process does a pattern match on this variable.
-	Version = "0.5.0"
+	Version = "0.6.0"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
@@ -44,7 +44,7 @@ func init() {
 // GetHumanVersion composes the parts of the version in a way that's suitable
 // for displaying to humans.
 func GetHumanVersion() string {
-	version := fmt.Sprintf("%s v%s",Name, Version)
+	version := fmt.Sprintf("%s v%s", Name, Version)
 
 	release := VersionPrerelease
 	if GitDescribe == "" && release == "" {


### PR DESCRIPTION
Hello,

Sometimes external consul nodes (more likely an external service) are only reachable trough TCP, it could be nice to define a TCP check for the node availability.
Port number could be defined in node's metadata with the following key / value :  `ping-type = "tcp:5432"`)

What do you think ? 
(Also I'm not a fluent gopher, remarks are more than welcomed )