### PR TITLE
basic docker build setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,59 +1,40 @@
-### Builder
+# This Dockerfile creates a production release image for the project. This
+# downloads the release from releases.hashicorp.com and therefore requires that
+# the release is published before building the Docker image.
 #
-FROM golang:latest AS builder
-LABEL maintainer "John Eikenberry <jae@zhar.net>"
-
-ARG LD_FLAGS
-ARG GOTAGS
-
-WORKDIR "/go/src/github.com/hashicorp/consul-esm"
-
-COPY . .
-
-RUN ls
-
-RUN \
-  CGO_ENABLED="0" \
-  GO111MODULE=on \
-  go build -a -o "/consul-esm" \
-    -ldflags "${LD_FLAGS}" -tags "${GOTAGS}"
-
-### Final
-#
+# We don't rebuild the software because we want the exact checksums and
+# binary signatures to match the software and our builds aren't fully
+# reproducible currently.
 FROM alpine:latest
+
+# NAME and VERSION are the name of the software in releases.hashicorp.com
+# and the version to download.
+ARG NAME=consul-esm
+ARG VERSION
+
+# version label is required for build process
 LABEL maintainer "John Eikenberry <jae@zhar.net>"
+LABEL version=$VERSION
 
 # UID and GID of consul-esm user and group.
 # These are the defaults, this makes them explicit and overridable.
 ARG UID=100
 ARG GID=1000
 
-# Create a consul-esm user and group first so the IDs get set the same way,
+# Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
+ENV NAME=${NAME}
+ENV VERSION=${VERSION}
+# This is the location of the releases.
+ENV HASHICORP_RELEASES=https://releases.hashicorp.com
+
+# Create a user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.
-RUN addgroup -g ${GID} consul-esm && \
-    adduser -u ${UID} -S -G consul-esm consul-esm
+RUN addgroup -g ${GID} ${NAME} && adduser -u ${UID} -S -G ${NAME} ${NAME}
 
-# Set up certificates, and dumb-init.
-RUN apk add --no-cache ca-certificates dumb-init
+# Set up certificates, base tools, and software.
+COPY fetch-n-verify.sh docker-entrypoint.sh /
+RUN /fetch-n-verify.sh # removes self when done
 
-# Install consul-esm
-COPY --from=builder "/consul-esm" "/bin/consul-esm"
-
-# The agent will be started with /consul-esm/config as the configuration
-# directory so you can add additional config files in that location.
-RUN mkdir -p /consul-esm/data && \
-    mkdir -p /consul-esm/config && \
-    chown -R consul-esm:consul-esm /consul-esm
-
-# Expose the consul-esm data directory as a volume since that's where
-# shared results should be rendered.
-VOLUME /consul-esm/data
-
-# The entry point script uses dumb-init as the top-level process to reap any
-# zombie processes created by consul-esm sub-processes.
-COPY "docker/alpine/docker-entrypoint.sh" "/bin/docker-entrypoint.sh"
-ENTRYPOINT ["/bin/docker-entrypoint.sh"]
-USER ${UID}:${GID}
-
-# Run consul-esm by default
-CMD ["/bin/consul-esm"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+USER ${NAME}:${NAME}
+CMD /bin/${NAME}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,59 @@
+### Builder
+#
+FROM golang:latest AS builder
+LABEL maintainer "John Eikenberry <jae@zhar.net>"
+
+ARG LD_FLAGS
+ARG GOTAGS
+
+WORKDIR "/go/src/github.com/hashicorp/consul-esm"
+
+COPY . .
+
+RUN ls
+
+RUN \
+  CGO_ENABLED="0" \
+  GO111MODULE=on \
+  go build -a -o "/consul-esm" \
+    -ldflags "${LD_FLAGS}" -tags "${GOTAGS}"
+
+### Final
+#
+FROM alpine:latest
+LABEL maintainer "John Eikenberry <jae@zhar.net>"
+
+# UID and GID of consul-esm user and group.
+# These are the defaults, this makes them explicit and overridable.
+ARG UID=100
+ARG GID=1000
+
+# Create a consul-esm user and group first so the IDs get set the same way,
+# even as the rest of this may change over time.
+RUN addgroup -g ${GID} consul-esm && \
+    adduser -u ${UID} -S -G consul-esm consul-esm
+
+# Set up certificates, and dumb-init.
+RUN apk add --no-cache ca-certificates dumb-init
+
+# Install consul-esm
+COPY --from=builder "/consul-esm" "/bin/consul-esm"
+
+# The agent will be started with /consul-esm/config as the configuration
+# directory so you can add additional config files in that location.
+RUN mkdir -p /consul-esm/data && \
+    mkdir -p /consul-esm/config && \
+    chown -R consul-esm:consul-esm /consul-esm
+
+# Expose the consul-esm data directory as a volume since that's where
+# shared results should be rendered.
+VOLUME /consul-esm/data
+
+# The entry point script uses dumb-init as the top-level process to reap any
+# zombie processes created by consul-esm sub-processes.
+COPY "docker/alpine/docker-entrypoint.sh" "/bin/docker-entrypoint.sh"
+ENTRYPOINT ["/bin/docker-entrypoint.sh"]
+USER ${UID}:${GID}
+
+# Run consul-esm by default
+CMD ["/bin/consul-esm"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/dumb-init /bin/sh
+set -e
+
+# Note above that we run dumb-init as PID 1 in order to reap zombie processes
+# as well as forward signals to all processes in its session. Normally, sh
+# wouldn't do either of these functions so we'd leak zombies as well as do
+# unclean termination of all our sub-processes.
+
+# CESM_CONFIG_DIR isn't exposed as a volume but you can compose additional config
+# files in there if you use this image as a base.
+CESM_CONFIG_DIR=/consul-esm/config
+
+# If the user is trying to run consul-esm directly with some arguments,
+# then pass them to consul-esm.
+# On alpine /bin/sh is busybox which supports the bashism below.
+if [ "${1:0:1}" = '-' ]
+then
+    set -- /bin/consul-esm "$@"
+fi
+
+# Set the configuration directory
+if [ "$1" = '/bin/consul-esm' ]
+then
+  shift
+  set -- /bin/consul-esm \
+    -config-dir="$CESM_CONFIG_DIR" \
+    "$@"
+fi
+
+exec "$@"

--- a/docker/fetch-n-verify.sh
+++ b/docker/fetch-n-verify.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# requires environment variables..
+#
+# HASHICORP_RELEASES - URL for releases
+# NAME - application's name
+# VERSION - application version (eg. 1.2.3)
+
+set -eux
+apk add --no-cache ca-certificates gnupg
+
+BUILD_GPGKEY=C874011F0AB405110D02105534365D9472D7468F
+found=''
+
+for server in \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://pgp.mit.edu:80 \
+; do
+    echo "Fetching GPG key $BUILD_GPGKEY from $server";
+    gpg --keyserver "$server" --recv-keys "$BUILD_GPGKEY" && found=yes && break;
+done
+
+test -z "$found" && echo >&2 "error: failed to fetch GPG key $BUILD_GPGKEY" && exit 1
+mkdir -p /tmp/build && cd /tmp/build
+
+apkArch="$(apk --print-arch)"
+case "${apkArch}" in \
+    aarch64) ARCH='arm64' ;;
+    armhf) ARCH='arm' ;;
+    x86) ARCH='386' ;;
+    x86_64) ARCH='amd64' ;;
+    *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/${NAME}/${VERSION}/)" && exit 1 ;;
+esac
+
+wget ${HASHICORP_RELEASES}/${NAME}/${VERSION}/${NAME}_${VERSION}_linux_${ARCH}.zip
+wget ${HASHICORP_RELEASES}/${NAME}/${VERSION}/${NAME}_${VERSION}_SHA256SUMS
+wget ${HASHICORP_RELEASES}/${NAME}/${VERSION}/${NAME}_${VERSION}_SHA256SUMS.sig
+gpg --batch --verify ${NAME}_${VERSION}_SHA256SUMS.sig ${NAME}_${VERSION}_SHA256SUMS
+grep ${NAME}_${VERSION}_linux_${ARCH}.zip ${NAME}_${VERSION}_SHA256SUMS | sha256sum -c
+unzip -d /bin ${NAME}_${VERSION}_linux_${ARCH}.zip
+
+apk del gnupg
+cd /tmp
+rm -rf /tmp/build
+gpgconf --kill gpg-agent || true
+rm -rf /root/.gnupg || true
+rm -f "$0"


### PR DESCRIPTION
based off consul-template one, simplified
includes Makefile targets for build and push

temporary solution until new build system is in place

allows #19 to be fixed once it is merged