### PR TITLE
Adopt new pgp key

### DIFF
--- a/build-support/docker/Release.dockerfile
+++ b/build-support/docker/Release.dockerfile
@@ -26,7 +26,7 @@ RUN addgroup ${NAME} && \
 # Set up certificates, base tools, and software.
 RUN set -eux && \
     apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils && \
-    BUILD_GPGKEY=91A6E7F85D05C65630BEF18951852D87348FFC4C; \
+    BUILD_GPGKEY=C874011F0AB405110D02105534365D9472D7468F; \
     found=''; \
     for server in \
         hkp://p80.pool.sks-keyservers.net:80 \


### PR DESCRIPTION
This adopts the new HashiCorp PGP key, as described at https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512/2 and https://hashicorp.com/security.

Please merge after reviewing 🙏 