### PR TITLE
Add support for TLSServerName for HTTP health checks

### DIFF
--- a/check.go
+++ b/check.go
@@ -98,6 +98,7 @@ func (c *CheckRunner) updateCheckHTTP(latestCheck *api.HealthCheck, checkHash ty
 	definition *api.HealthCheckDefinition, updated, added checkIDSet) bool {
 	tlsConfig := c.tlsConfig.Clone()
 	tlsConfig.InsecureSkipVerify = definition.TLSSkipVerify
+	tlsConfig.ServerName = definition.TLSServerName
 
 	http := &consulchecks.CheckHTTP{
 		Notify:   c,


### PR DESCRIPTION
This enables custom SNI/TLSServerName for HTTP health checks. This is essentially a followup for hashicorp/consul-esm#102.