### PR TITLE
[WIP] Feature/add grpc checks

### DIFF
--- a/check.go
+++ b/check.go
@@ -231,11 +231,12 @@ func (c *CheckRunner) updateCheckGRPC(latestCheck *api.HealthCheck, checkHash ty
 	tlsConfig.InsecureSkipVerify = definition.TLSSkipVerify
 
 	grpc := &consulchecks.CheckGRPC{
-		Notify:   c,
-		CheckID:  checkHash,
-		GRPC:     definition.GRPC,
-		Interval: definition.IntervalDuration,
-		Timeout:  definition.TimeoutDuration,
+		Notify:     c,
+		CheckID:    checkHash,
+		GRPC:       definition.GRPC,
+		GRPCUseTLS: definition.GRPCUseTLS,
+		Interval:   definition.IntervalDuration,
+		Timeout:    definition.TimeoutDuration,
 		Logger: c.logger.StandardLogger(&hclog.StandardLoggerOptions{
 			InferLevels: true,
 		}),


### PR DESCRIPTION
Hi guys, I am trying to add support for GRPC checks following https://github.com/hashicorp/consul-esm/issues/117

For some reason, when this line runs: https://github.com/VictorBac/consul-esm/blob/feature/add-grpc-checks/check.go#L488
my check is updated, but some information are deleted (causing following checks to be invalid)

Going from:

```
$ curl http://consul:8500/v1/health/node/external-node?pretty
...
            "Definition": {
                "grpc": "my-grpc-service.com:443",
                "TLSSkipVerify": true,
                "GRPCUseTLS": true,
                "interval": "10s"
            }
```
to:
```             
            "Definition": {
                "TLSSkipVerify": true,
                "interval": "10s"
            }
```

and the GRPCUseTLS does not seem to be respected.

PS: to build this, I had too add GRPC to the check definition:
https://github.com/hashicorp/consul/pull/12108/files

Do you know what I am missing here ?