### PR TITLE
Deregister register bug

### DIFF
--- a/coordinate.go
+++ b/coordinate.go
@@ -79,11 +79,12 @@ func (a *Agent) updateCoords(nodeCh nodeChannel) {
 		a.inflightLock.Lock()
 		if _, ok := a.inflightPings[node.Node]; ok {
 			a.logger.Warn("Error pinging node, last request still outstanding", "node", node.Node, "nodeId", node.ID)
+			a.inflightLock.Unlock()
 		} else {
 			a.inflightPings[node.Node] = struct{}{}
+			a.inflightLock.Unlock()
 			go a.runNodePing(node)
 		}
-		a.inflightLock.Unlock()
 	}
 }
 

--- a/coordinate.go
+++ b/coordinate.go
@@ -22,11 +22,10 @@ const (
 	MetaSegmentKey = "consul-network-segment"
 )
 
-var (
-	// The maximum time to wait for a ping to complete.
-	MaxRTT = 5 * time.Second
-)
 type nodeChannel <-chan []*api.Node
+
+// The maximum time to wait for a ping to complete.
+var MaxRTT = 5 * time.Second
 
 // updateCoords is a long running goroutine that attempts to ping all external nodes
 // once per CoordinateUpdateInterval and update their statuses in Consul.


### PR DESCRIPTION
Bug desc: Deregister a node then re-registering it quickly would lead to a node without coordiates, etc. for a time as there is a timed based status entry that needed to expire before the re-registration would be complete with coordinates and all.

This change clears out those saved status along with the making sure the inflight ping tracking is also cleared. So that the re-registered node can be processed normally.

Fixes #119