### PR TITLE
bug fix: ESM doesn't deregister if status and output are same as before

### DIFF
--- a/check.go
+++ b/check.go
@@ -305,6 +305,11 @@ func (c *CheckRunner) UpdateCheck(checkID types.CheckID, status, output string) 
 
 	// Do nothing if update is idempotent
 	if check.Status == status && check.Output == output {
+		if status == api.HealthCritical {
+			if _, ok := c.checksCritical[checkID]; !ok {
+				c.checksCritical[checkID] = time.Now()
+			}
+		}
 		check.failureCounter = decrementCounter(check.failureCounter)
 		check.successCounter = decrementCounter(check.successCounter)
 		return


### PR DESCRIPTION
## Describe bug

Let's say ESM is restarted by some reasons or new ESM is enrolled in cluster and there is a service that should be deregistered after `DeregisterCriticalServiceAfter`. At the moment, because of [idempotent check](https://github.com/hashicorp/consul-esm/blob/v0.6.0/check.go#L305-L310) and early return, ESM doesn't have `criticalTime` in memory that decides whether to deregister it or not so external service will not be deregistered.

## How to reproduce

1. register external service with wrong health check
2. run ESM to update it to critical status (make sure that status and output are always same)
3. restart ESM
4. it is not deregistered even it exceeds `DeregisterCriticalServiceAfter`
