### PR TITLE
Include TLSServerName in early return equality check

### DIFF
--- a/check.go
+++ b/check.go
@@ -119,6 +119,7 @@ func (c *CheckRunner) updateCheckHTTP(latestCheck *api.HealthCheck, checkHash ty
 			reflect.DeepEqual(httpCheck.Header, http.Header) &&
 			httpCheck.Method == http.Method &&
 			httpCheck.TLSClientConfig.InsecureSkipVerify == http.TLSClientConfig.InsecureSkipVerify &&
+			httpCheck.TLSClientConfig.ServerName == http.TLSClientConfig.ServerName &&
 			httpCheck.Interval == http.Interval &&
 			httpCheck.Timeout == http.Timeout &&
 			check.Definition.DeregisterCriticalServiceAfter == definition.DeregisterCriticalServiceAfter {


### PR DESCRIPTION
Support for `TLSServerName` was added in #116, but this early return
equality check wasn't updated to include the new field. The impact is
changes to the value of `TLSServerName` aren't picked up by the health
checks unless accompanied by other changes to the check definition.