### PR TITLE
logging refactor missed the log_json setting

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 		LogLevel:       config.LogLevel,
 		EnableSyslog:   config.EnableSyslog,
 		SyslogFacility: config.SyslogFacility,
+		LogJSON:        config.LogJSON,
 	}
 	logger, err := logging.Setup(logConfig, os.Stdout)
 	if err != nil {


### PR DESCRIPTION
The log_json setting wasn't being propagated to the underlying consul logging setup. It was missed when I refactored the logging for the last release to use consul's new internal hclogger.

