### PR TITLE
fix deadlock in check runner

### DIFF
--- a/check.go
+++ b/check.go
@@ -241,7 +241,7 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 			continue
 		}
 
-		checkHash := checkHash(check)
+		checkHash := hashCheck(check)
 
 		// create a copy of the definition that will be modified
 		definition := check.Definition
@@ -286,7 +286,7 @@ func (c *CheckRunner) UpdateChecks(checks api.HealthChecks) {
 
 	// Look for removed checks
 	for _, check := range c.checks {
-		checkHash := checkHash(&check.HealthCheck)
+		checkHash := hashCheck(&check.HealthCheck)
 		if _, ok := found[checkHash]; !ok {
 			c.logger.Debug("Deleting check %q", "checkHash", checkHash)
 			delete(c.checks, checkHash)
@@ -503,7 +503,7 @@ func (c *CheckRunner) reapServicesInternal() {
 	}
 }
 
-func checkHash(check *api.HealthCheck) types.CheckID {
+func hashCheck(check *api.HealthCheck) types.CheckID {
 	if check.ServiceID != "" {
 		return types.CheckID(fmt.Sprintf("%s/%s/%s", check.Node, check.ServiceID, check.CheckID))
 	}

--- a/check_test.go
+++ b/check_test.go
@@ -286,7 +286,7 @@ func TestCheck_MinimumInterval(t *testing.T) {
 	}
 
 	// confirm that esm's modified version of check's interval is updated
-	esmCheck, ok := runner.checksHTTP[checkHash(check)]
+	esmCheck, ok := runner.checksHTTP.Load(checkHash(check))
 	if !ok {
 		t.Fatalf("HTTP check was not stored on runner.checksHTTP as expected. Checks: %v", runner.checksHTTP)
 	}

--- a/check_test.go
+++ b/check_test.go
@@ -277,7 +277,7 @@ func TestCheck_MinimumInterval(t *testing.T) {
 	runner.UpdateChecks(checks)
 
 	// confirm that the original check's interval is unmodified
-	originalCheck, ok := runner.checks[checkHash(check)]
+	originalCheck, ok := runner.checks[hashCheck(check)]
 	if !ok {
 		t.Fatalf("Check was not stored on runner.checks as expected. Checks: %v", runner.checks)
 	}
@@ -286,7 +286,7 @@ func TestCheck_MinimumInterval(t *testing.T) {
 	}
 
 	// confirm that esm's modified version of check's interval is updated
-	esmCheck, ok := runner.checksHTTP.Load(checkHash(check))
+	esmCheck, ok := runner.checksHTTP.Load(hashCheck(check))
 	if !ok {
 		t.Fatalf("HTTP check was not stored on runner.checksHTTP as expected. Checks: %v", runner.checksHTTP)
 	}
@@ -349,7 +349,7 @@ func TestCheck_NoFlapping(t *testing.T) {
 
 	runner.UpdateChecks(checks)
 
-	hash := checkHash(checks[0])
+	hash := hashCheck(checks[0])
 	id := structs.CheckID{ID: hash}
 
 	originalCheck, ok := runner.checks[hash]

--- a/leader_test.go
+++ b/leader_test.go
@@ -68,7 +68,7 @@ func (a *Agent) verifyUpdates(t *testing.T, expectedHealthNodes, expectedProbeNo
 		a.checkRunner.RLock()
 		defer a.checkRunner.RUnlock()
 		for _, check := range ourChecks {
-			hash := checkHash(check)
+			hash := hashCheck(check)
 			if _, ok := a.checkRunner.checks[hash]; !ok {
 				r.Fatalf("missing check %v", hash)
 			}
@@ -154,7 +154,8 @@ func TestLeader_rebalanceHealthWatches(t *testing.T) {
 		Address:    "127.0.0.1",
 		Datacenter: "dc1",
 		NodeMeta: map[string]string{
-			"external-node": "true"},
+			"external-node": "true",
+		},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -448,7 +449,7 @@ func Test_namespacesList(t *testing.T) {
 		}))
 	defer ts.Close()
 
-	//client, err := api.NewClient(&api.Config{Address: "127.0.0.1:8500"})
+	// client, err := api.NewClient(&api.Config{Address: "127.0.0.1:8500"})
 	client, err := api.NewClient(&api.Config{Address: ts.URL})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
CheckRunner had a race where it would deadlock if the right timing of Stop() and an internal run of the check. They'd lock on the checkrunner's Mutex.

This replaces the 2 maps used in Stop from being protected by the mutext to sync.Map instances. They handle the mutex all internally and don't need to use the CR one so they no longer trigger the deadlock on Stop.

The CR really needs to be reworked a bit to minimize/eliminate the internal state maps and the need for the lock, but that is a large refactor while this fixes it with minimal changes.

Fixes #159 

Note this also includes a second commit that addresses some naming confusion in the same code. Went ahead and included it here as it touched the same code but I plan to use a rebase-merge to disassociate the commits on the main branch. 