### PR TITLE
Add optional support for the pprof endpoints

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ const (
 
 type Config struct {
 	LogLevel       string
+	EnableDebug    bool
 	EnableSyslog   bool
 	SyslogFacility string
 	LogJSON        bool
@@ -156,6 +157,7 @@ type Telemetry struct {
 // HumanConfig contains configuration that the practitioner can set
 type HumanConfig struct {
 	LogLevel       flags.StringValue `mapstructure:"log_level"`
+	EnableDebug    flags.BoolValue   `mapstructure:"enable_debug"`
 	EnableSyslog   flags.BoolValue   `mapstructure:"enable_syslog"`
 	SyslogFacility flags.StringValue `mapstructure:"syslog_facility"`
 	LogJSON        flags.BoolValue   `mapstructure:"log_json"`
@@ -453,6 +455,7 @@ func convertTelemetry(telemetry Telemetry) (lib.TelemetryConfig, error) {
 func MergeConfig(dst *Config, src *HumanConfig) error {
 	src.LogLevel.Merge(&dst.LogLevel)
 	src.LogJSON.Merge(&dst.LogJSON)
+	src.EnableDebug.Merge(&dst.EnableDebug)
 	src.EnableSyslog.Merge(&dst.EnableSyslog)
 	src.InstanceID.Merge(&dst.InstanceID)
 	src.Service.Merge(&dst.Service)

--- a/config_test.go
+++ b/config_test.go
@@ -15,6 +15,7 @@ import (
 func TestDecodeMergeConfig(t *testing.T) {
 	raw := bytes.NewBufferString(`
 log_level = "INFO"
+enable_debug = true
 enable_syslog = true
 instance_id = "test-instance-id"
 consul_service = "service"
@@ -72,6 +73,7 @@ log_json = true
 
 	expected := &Config{
 		LogLevel:                 "INFO",
+		EnableDebug:              true,
 		InstanceID:               "test-instance-id",
 		Service:                  "service",
 		Tag:                      "asdf",


### PR DESCRIPTION
The pprof endpoints are enabled by the enable_debug flag, matching the Consul behavior.