### PR TITLE
eliminate struct level lock on checkrunner

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -277,7 +277,7 @@ func TestCheck_MinimumInterval(t *testing.T) {
 	runner.UpdateChecks(checks)
 
 	// confirm that the original check's interval is unmodified
-	originalCheck, ok := runner.checks[hashCheck(check)]
+	originalCheck, ok := runner.checks.Load(hashCheck(check))
 	if !ok {
 		t.Fatalf("Check was not stored on runner.checks as expected. Checks: %v", runner.checks)
 	}
@@ -352,7 +352,7 @@ func TestCheck_NoFlapping(t *testing.T) {
 	hash := hashCheck(checks[0])
 	id := structs.CheckID{ID: hash}
 
-	originalCheck, ok := runner.checks[hash]
+	originalCheck, ok := runner.checks.Load(hash)
 	if !ok {
 		t.Fatalf("Check was not stored on runner.checks as expected. Checks: %v", runner.checks)
 	}
@@ -414,7 +414,7 @@ func TestCheck_NoFlapping(t *testing.T) {
 	assert.Equal(t, api.HealthCritical, originalCheck.Status)
 
 	runner.UpdateChecks(checks)
-	currentCheck, ok := runner.checks[hash]
+	currentCheck, ok := runner.checks.Load(hash)
 	if !ok {
 		t.Fatalf("Current check was not stored on runner.checks as expected. Checks: %v", runner.checks)
 	}

--- a/leader_test.go
+++ b/leader_test.go
@@ -65,15 +65,16 @@ func (a *Agent) verifyUpdates(t *testing.T, expectedHealthNodes, expectedProbeNo
 
 		// Make sure the check runner is watching all the health checks on the
 		// expected nodes and nothing else.
-		a.checkRunner.RLock()
-		defer a.checkRunner.RUnlock()
 		for _, check := range ourChecks {
 			hash := hashCheck(check)
-			if _, ok := a.checkRunner.checks[hash]; !ok {
+			if _, ok := a.checkRunner.checks.Load(hash); !ok {
 				r.Fatalf("missing check %v", hash)
 			}
 		}
-		if len(ourChecks) != len(a.checkRunner.checks) {
+		var checksLen int
+		a.checkRunner.checks.Range(
+			func(_, _ any) bool { checksLen++; return true })
+		if len(ourChecks) != checksLen {
 			r.Fatalf("checks do not match: %+v, %+v", ourChecks, a.checkRunner.checks)
 		}
 	})


### PR DESCRIPTION
The weird calling pattern (an esm call passes a value with a callback into another esm method) kept triggering deadlocks. This change converts all maps to sync.Maps and uses their internal syncing to keep things in sync with no locks.

Plus updates to impacted tests.

Fixes #192