### PR TITLE
fix goroutine leak

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -509,9 +509,13 @@ func (a *Agent) getHealthChecks(waitIndex uint64, nodes map[string]bool) (api.He
 		NodeMeta:  a.config.NodeMeta,
 		WaitIndex: waitIndex,
 	}).WithContext(ctx)
+	defer cancelFunc()
 	go func() {
-		<-a.shutdownCh
-		cancelFunc()
+		select {
+		case <-a.shutdownCh:
+			cancelFunc()
+		case <-ctx.Done():
+		}
 	}()
 
 	ourChecks := make(api.HealthChecks, 0)


### PR DESCRIPTION
goroutine didn't have a way to exit on the golden path. sigh.

Fixes: #194