### PR TITLE
Reload consul configuration

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -59,13 +59,16 @@ func (s lastKnownStatus) isExpired(ttl time.Duration, now time.Time) bool {
 type Agent struct {
 	config      *Config
 	client      *api.Client
+	clientLock  sync.RWMutex
 	logger      hclog.Logger
 	checkRunner *CheckRunner
 	id          string
 
-	shutdownCh chan struct{}
-	shutdown   bool
-	ready      chan struct{}
+	reloadCh     chan struct{}
+	reloadChLock sync.Mutex
+	shutdownCh   chan struct{}
+	shutdown     bool
+	ready        chan struct{}
 
 	inflightPings map[string]struct{}
 	inflightLock  sync.Mutex
@@ -96,6 +99,7 @@ func NewAgent(config *Config, logger hclog.Logger) (*Agent, error) {
 		client:            client,
 		id:                config.InstanceID,
 		logger:            logger,
+		reloadCh:          make(chan struct{}),
 		shutdownCh:        make(chan struct{}),
 		ready:             make(chan struct{}, 1),
 		inflightPings:     make(map[string]struct{}),
@@ -122,7 +126,7 @@ func NewAgent(config *Config, logger hclog.Logger) (*Agent, error) {
 
 func (a *Agent) Run() error {
 	// Do the initial service registration.
-	if err := a.register(); err != nil {
+	if err := a.register(false); err != nil {
 		return err
 	}
 
@@ -165,7 +169,7 @@ func (a *Agent) Run() error {
 	wg.Wait()
 
 	// Clean up.
-	if err := a.client.Agent().ServiceDeregister(a.serviceID()); err != nil {
+	if err := a.getClient().Agent().ServiceDeregister(a.serviceID()); err != nil {
 		a.logger.Warn("Failed to deregister service", "error", err)
 	}
 
@@ -176,6 +180,47 @@ func (a *Agent) Shutdown() {
 	if !a.shutdown {
 		a.shutdown = true
 		close(a.shutdownCh)
+	}
+}
+
+func (a *Agent) Reload(new *Config) error {
+	if consulConfigHasChanged(a.config, new) {
+		a.clientLock.Lock()
+		client, err := api.NewClient(new.ClientConfig())
+		if err != nil {
+			return err
+		}
+		a.client = client
+		a.clientLock.Unlock()
+		a.triggerReload()
+	}
+	a.config = new
+	return nil
+}
+
+func (a *Agent) getClient() *api.Client {
+	a.clientLock.RLock()
+	defer a.clientLock.RUnlock()
+	return a.client
+}
+
+func (a *Agent) reloadWatcher() <-chan struct{} {
+	a.reloadChLock.Lock()
+	defer a.reloadChLock.Unlock()
+
+	if a.reloadCh == nil {
+		a.reloadCh = make(chan struct{})
+	}
+
+	return a.reloadCh
+}
+
+func (a *Agent) triggerReload() {
+	a.reloadChLock.Lock()
+	defer a.reloadChLock.Unlock()
+	if a.reloadCh != nil {
+		close(a.reloadCh)
+		a.reloadCh = nil
 	}
 }
 
@@ -198,10 +243,13 @@ func (e *alreadyExistsError) Error() string {
 }
 
 // register is used to register this agent with Consul service discovery.
-func (a *Agent) register() error {
-	// agent ids need to be unique to disambiguate different instances on same host
-	if existing, _, _ := a.client.Agent().Service(a.serviceID(), nil); existing != nil {
-		return &alreadyExistsError{a.serviceID()}
+func (a *Agent) register(reregister bool) error {
+	// If are reregistering we can't check for duplicates as there will be
+	if !reregister {
+		// agent ids need to be unique to disambiguate different instances on same host
+		if existing, _, _ := a.getClient().Agent().Service(a.serviceID(), nil); existing != nil {
+			return &alreadyExistsError{a.serviceID()}
+		}
 	}
 
 	service := &api.AgentServiceRegistration{
@@ -212,7 +260,7 @@ func (a *Agent) register() error {
 	if a.config.Tag != "" {
 		service.Tags = []string{a.config.Tag}
 	}
-	if err := a.client.Agent().ServiceRegister(service); err != nil {
+	if err := a.getClient().Agent().ServiceRegister(service); err != nil {
 		return err
 	}
 	a.logger.Debug("Registered ESM service with Consul")
@@ -273,28 +321,33 @@ func (a *Agent) runHTTP() {
 func (a *Agent) runRegister() {
 	serviceID := a.serviceID()
 	for {
-	REGISTER_CHECK:
+		var reregister bool
 		select {
 		case <-a.shutdownCh:
 			return
-
+		case <-a.reloadWatcher():
+			a.logger.Info("Reload triggered. Reregistering service")
+			reregister = true
 		case <-time.After(agentTTL):
-			services, err := a.client.Agent().Services()
+		}
+		if !reregister {
+			services, err := a.getClient().Agent().Services()
 			if err != nil {
 				a.logger.Error("Failed to check services (will retry)", "error", err)
 				time.Sleep(retryTime)
-				goto REGISTER_CHECK
+				continue
 			}
-
-			if _, ok := services[serviceID]; !ok {
-				a.logger.Warn("Service registration was lost, reregistering")
-				if err := a.register(); err != nil {
-					a.logger.Error("Failed to reregister service (will retry)", "error", err)
-					time.Sleep(retryTime)
-					goto REGISTER_CHECK
-				}
+			if _, ok := services[serviceID]; ok {
+				continue
 			}
+			a.logger.Warn("Service registration was lost, reregistering")
 		}
+		if err := a.register(reregister); err != nil {
+			a.logger.Error("Failed to reregister service (will retry)", "error", err)
+			time.Sleep(retryTime)
+			continue
+		}
+		reregister = false
 	}
 }
 
@@ -323,7 +376,7 @@ REGISTER:
 			DeregisterCriticalServiceAfter: deregisterTime.String(),
 		},
 	}
-	if err := a.client.Agent().CheckRegister(check); err != nil {
+	if err := a.getClient().Agent().CheckRegister(check); err != nil {
 		a.logger.Error("Failed to register TTL check (will retry)", "error", err)
 		time.Sleep(retryTime)
 		goto REGISTER
@@ -334,9 +387,10 @@ REGISTER:
 		select {
 		case <-a.shutdownCh:
 			return
-
+		case <-a.reloadWatcher():
+			goto REGISTER
 		case <-time.After(agentTTL / 2):
-			if err := a.client.Agent().UpdateTTL(ttlID, "", api.HealthPassing); err != nil {
+			if err := a.getClient().Agent().UpdateTTL(ttlID, "", api.HealthPassing); err != nil {
 				a.logger.Error("Failed to refresh agent TTL check (will reregister)", "error", err)
 				time.Sleep(retryTime)
 				goto REGISTER
@@ -382,7 +436,7 @@ func (a *Agent) watchNodeList() {
 		}
 
 		// Get the KV entry for this agent's node list.
-		kv, meta, err := a.client.KV().Get(a.kvNodeListPath()+a.serviceID(), opts)
+		kv, meta, err := a.getClient().KV().Get(a.kvNodeListPath()+a.serviceID(), opts)
 		if err != nil {
 			a.logger.Warn("Error querying for node watch list", "error", err)
 			time.Sleep(retryTime)
@@ -413,7 +467,7 @@ func (a *Agent) watchNodeList() {
 			pingNodes[node] = true
 		}
 
-		nodes, _, err := a.client.Catalog().Nodes(&api.QueryOptions{NodeMeta: a.config.NodeMeta})
+		nodes, _, err := a.getClient().Catalog().Nodes(&api.QueryOptions{NodeMeta: a.config.NodeMeta})
 		if err != nil {
 			a.logger.Warn("Error querying for node list", "error", err)
 			continue
@@ -528,7 +582,7 @@ func (a *Agent) getHealthChecks(waitIndex uint64, nodes map[string]bool) (api.He
 		if ns.Name != "" { // ns.Name only set on enterprise version
 			a.logger.Info("checking namespaces for services", "name", ns.Name)
 		}
-		checks, meta, err := a.client.Health().State(api.HealthAny, opts)
+		checks, meta, err := a.getClient().Health().State(api.HealthAny, opts)
 		if err != nil {
 			a.logger.Warn("Error querying for health check info", "error", err)
 			continue
@@ -574,7 +628,7 @@ func (a *Agent) VerifyConsulCompatibility() error {
 	}
 
 	// Fetch local agent version
-	agentInfo, err := a.client.Agent().Self()
+	agentInfo, err := a.getClient().Agent().Self()
 	if err != nil {
 		// ESM blocks in NewAgent() until agent is available. At this point
 		// /agent/self endpoint should be available and an error would not be useful
@@ -595,7 +649,7 @@ VERIFYCONSULSERVER:
 	}
 
 	// Fetch server versions
-	svs, _, err := a.client.Catalog().Service("consul", "", nil)
+	svs, _, err := a.getClient().Catalog().Service("consul", "", nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "429") {
 			// 429 is a warning that something is unhealthy. This may occur when ESM

--- a/agent.go
+++ b/agent.go
@@ -583,7 +583,7 @@ func (a *Agent) getHealthChecks(waitIndex uint64, nodes map[string]bool) (api.He
 	for _, ns := range namespaces {
 		opts.Namespace = ns.Name
 		if ns.Name != "" { // ns.Name only set on enterprise version
-			a.logger.Info("checking namespaces for services", "name", ns.Name)
+			a.logger.Info("checking namespaces for checks", "name", ns.Name)
 		}
 		checks, meta, err := a.getClient().Health().State(api.HealthAny, opts)
 		if err != nil {

--- a/check.go
+++ b/check.go
@@ -30,8 +30,9 @@ var defaultInterval = 30 * time.Second
 type checkIDSet map[types.CheckID]bool
 
 type CheckRunner struct {
-	logger hclog.Logger
-	client *api.Client
+	logger     hclog.Logger
+	client     *api.Client
+	clientLock sync.RWMutex
 
 	// checks are unmodified checks as retrieved from Consul Catalog
 	checks checkMap[types.CheckID, *esmHealthCheck]
@@ -120,6 +121,18 @@ func NewCheckRunner(logger hclog.Logger, client *api.Client, updateInterval,
 func (c *CheckRunner) Stop() {
 	c.checksHTTP.StopAll()
 	c.checksTCP.StopAll()
+}
+
+func (c *CheckRunner) setClient(client *api.Client) {
+	c.clientLock.Lock()
+	c.client = client
+	c.clientLock.Unlock()
+}
+
+func (c *CheckRunner) getClient() *api.Client {
+	c.clientLock.RLock()
+	defer c.clientLock.RUnlock()
+	return c.client
 }
 
 // Update an HTTP check
@@ -417,7 +430,7 @@ func (c *CheckRunner) UpdateCheck(checkID structs.CheckID, status, output string
 func (c *CheckRunner) handleCheckUpdate(check *api.HealthCheck, status, output string) {
 	// Exit early if the check or node have been deregistered.
 	// consistent mode reduces convergency time particularly when services have many updates in a short time
-	checks, _, err := c.client.Health().Node(check.Node, &api.QueryOptions{RequireConsistent: true})
+	checks, _, err := c.getClient().Health().Node(check.Node, &api.QueryOptions{RequireConsistent: true})
 	if err != nil {
 		c.logger.Warn("error retrieving existing node entry", "error", err)
 		return
@@ -448,7 +461,7 @@ func (c *CheckRunner) handleCheckUpdate(check *api.HealthCheck, status, output s
 		},
 	}
 	metrics.IncrCounter([]string{"check", "txn"}, 1)
-	ok, resp, _, err := c.client.Txn().Txn(ops, nil)
+	ok, resp, _, err := c.getClient().Txn().Txn(ops, nil)
 	if err != nil {
 		c.logger.Warn("Error updating check status in Consul", "error", err)
 		return
@@ -516,7 +529,7 @@ func (c *CheckRunner) reapServicesInternal() {
 
 		timeout := check.Definition.DeregisterCriticalServiceAfterDuration
 		if timeout > 0 && timeout < time.Since(criticalTime) {
-			c.client.Catalog().Deregister(&api.CatalogDeregistration{
+			c.getClient().Catalog().Deregister(&api.CatalogDeregistration{
 				Node:      ID.node,
 				ServiceID: ID.service,
 			}, nil)

--- a/check.go
+++ b/check.go
@@ -253,7 +253,6 @@ func (c *CheckRunner) updateCheckTCP(
 
 		updated[checkHash] = true
 	} else {
-
 		c.logger.Debug("Added TCP check", "checkHash", checkHash)
 		added[checkHash] = true
 	}

--- a/config.go
+++ b/config.go
@@ -496,3 +496,13 @@ func MergeConfig(dst *Config, src *HumanConfig) error {
 	src.CriticalThreshold.Merge(&dst.CriticalThreshold)
 	return nil
 }
+
+func consulConfigHasChanged(old, new *Config) bool {
+	if old.Token != new.Token {
+		return true
+	}
+	if old.CAFile != new.CAFile || old.CertFile != new.CertFile || old.KeyFile != new.KeyFile {
+		return true
+	}
+	return false
+}

--- a/coordinate.go
+++ b/coordinate.go
@@ -94,7 +94,7 @@ func (a *Agent) updateCoords(nodeCh nodeChannel) {
 // runNodePing pings a node and updates its status in Consul accordingly.
 func (a *Agent) runNodePing(node *api.Node) {
 	// Get the critical status of the node.
-	kvClient := a.client.KV()
+	kvClient := a.getClient().KV()
 	key := fmt.Sprintf("%sprobes/%s", a.config.KVPath, node.Node)
 	kvPair, _, err := kvClient.Get(key, nil)
 	if err != nil {
@@ -243,7 +243,7 @@ func (a *Agent) updateFailedNodeTxn(node *api.Node, kvClient *api.KV, key string
 
 			// If the node still exists in the catalog, add an atomic delete on the node to
 			// the list of operations to run.
-			existing, _, err := a.client.Catalog().Node(node.Node, nil)
+			existing, _, err := a.getClient().Catalog().Node(node.Node, nil)
 			if err != nil {
 				return fmt.Errorf("could not fetch existing node %q: %v", node.Node, err)
 			}
@@ -294,7 +294,7 @@ func (a *Agent) updateNodeCheck(node *api.Node, ops api.TxnOps, status, output s
 // runClientTxn runs the given transaction using the configured Consul client and
 // returns any errors encountered.
 func (a *Agent) runClientTxn(ops api.TxnOps) error {
-	ok, resp, _, err := a.client.Txn().Txn(ops, nil)
+	ok, resp, _, err := a.getClient().Txn().Txn(ops, nil)
 	if err != nil {
 		return err
 	}
@@ -321,7 +321,7 @@ func (a *Agent) updateNodeCoordinate(node *api.Node, rtt time.Duration) error {
 	}
 
 	// Get coordinate info for the node.
-	coords, _, err := a.client.Coordinate().Node(node.Node, nil)
+	coords, _, err := a.getClient().Coordinate().Node(node.Node, nil)
 	if err != nil && !strings.Contains(err.Error(), "Unexpected response code: 404") {
 		return fmt.Errorf("error getting coordinate for node %q: %v, skipping update", node.Node, err)
 	}
@@ -341,7 +341,7 @@ func (a *Agent) updateNodeCoordinate(node *api.Node, rtt time.Duration) error {
 	}
 
 	// Get the local agent's coordinate info.
-	self, err := a.client.Agent().Self()
+	self, err := a.getClient().Agent().Self()
 	if err != nil {
 		return fmt.Errorf("could not retrieve local agent's coordinate info: %v", err)
 	}
@@ -373,7 +373,7 @@ func (a *Agent) updateNodeCoordinate(node *api.Node, rtt time.Duration) error {
 		return nil
 	}
 
-	_, err = a.client.Coordinate().Update(&api.CoordinateEntry{
+	_, err = a.getClient().Coordinate().Update(&api.CoordinateEntry{
 		Node:    coord.Node,
 		Segment: coord.Segment,
 		Coord:   newCoord,

--- a/leader.go
+++ b/leader.go
@@ -39,7 +39,7 @@ LEADER_WAIT:
 	a.logger.Info("Trying to obtain leadership...")
 	if lock == nil {
 		var err error
-		lock, err = a.client.LockKey(a.config.KVPath + LeaderKey)
+		lock, err = a.getClient().LockKey(a.config.KVPath + LeaderKey)
 		if err != nil {
 			a.logger.Error("Error trying to create leader lock (will retry)", "error", err)
 			time.Sleep(retryTime)
@@ -107,7 +107,7 @@ func nodeLists(nodes []*api.Node, insts []*api.ServiceEntry,
 }
 
 func (a *Agent) commitOps(ops api.KVTxnOps) bool {
-	success, results, _, err := a.client.KV().Txn(ops, nil)
+	success, results, _, err := a.getClient().KV().Txn(ops, nil)
 	if err != nil || !success {
 		a.logger.Error("Error writing state to KV store", "results", results, "error", err)
 		// Try again after the wait because we got an error.
@@ -226,7 +226,7 @@ func (a *Agent) watchExternalNodes(nodeCh chan []*api.Node, stopCh <-chan struct
 		firstRun = false
 
 		// Do a blocking query for any external node changes
-		externalNodes, meta, err := a.client.Catalog().Nodes(opts)
+		externalNodes, meta, err := a.getClient().Catalog().Nodes(opts)
 		if err != nil {
 			a.logger.Warn("Error getting external node list", "error", err)
 			continue
@@ -292,7 +292,7 @@ func (a *Agent) getServiceInstances(opts *api.QueryOptions) ([]*api.ServiceEntry
 			a.logger.Info("checking namespaces for services", "name", ns.Name)
 		}
 		opts.Namespace = ns.Name
-		healthy, m, err := a.client.Health().Service(a.config.Service,
+		healthy, m, err := a.getClient().Health().Service(a.config.Service,
 			a.config.Tag, true, opts)
 		if err != nil {
 			return nil, err

--- a/leader.go
+++ b/leader.go
@@ -282,7 +282,7 @@ func (a *Agent) getServiceInstances(opts *api.QueryOptions) ([]*api.ServiceEntry
 	var healthyInstances []*api.ServiceEntry
 	var meta *api.QueryMeta
 
-	namespaces, err := namespacesList(a.client)
+	namespaces, err := namespacesList(a.getClient())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Attemps to fix #53.

This PR allows to reload the configuration to reload the consul values like token, certs ...
This is useful when deploying the ESM with short lived consul credentials (nomad - vault integration)

Changes:
- Intercep sighup signal to reload
- Create a lock around the client using the getClient() method so each time we use it there was a change in configuration it'll use the new client.
- Change how leader routine works. As the lock struct doesn't allow to change the client. We need to stop the lock and create it again.
