### PR TITLE
Allow configuring NodeHealthRefreshInterval

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ node_reconnect_timeout = "72h"
 // update the coordinates for all nodes it is watching every 10 seconds.
 node_probe_interval = "10s"
 
+// The length of time to wait before updating the health status of a node.
+// Note that the reaping process due to failed pings wont be triggered after
+// the health status is updated, so if node_reconnect_timeout is lower than
+// this parameter, it won't be triggered until this interval has expired.
+node_health_refresh_interval = "1h"
+
 // Controls whether or not to disable calculating and updating node coordinates
 // when doing the node probe. Defaults to false i.e. coordinate updates
 // are enabled.

--- a/config.go
+++ b/config.go
@@ -170,8 +170,9 @@ type HumanConfig struct {
 	KVPath     flags.StringValue   `mapstructure:"consul_kv_path"`
 	NodeMeta   []map[string]string `mapstructure:"external_node_meta"`
 
-	NodeReconnectTimeout flags.DurationValue `mapstructure:"node_reconnect_timeout"`
-	NodeProbeInterval    flags.DurationValue `mapstructure:"node_probe_interval"`
+	NodeReconnectTimeout      flags.DurationValue `mapstructure:"node_reconnect_timeout"`
+	NodeProbeInterval         flags.DurationValue `mapstructure:"node_probe_interval"`
+	NodeHealthRefreshInterval flags.DurationValue `mapstructure:"node_health_refresh_interval"`
 
 	HTTPAddr      flags.StringValue `mapstructure:"http_addr"`
 	Token         flags.StringValue `mapstructure:"token"`
@@ -468,6 +469,7 @@ func MergeConfig(dst *Config, src *HumanConfig) error {
 	}
 	src.NodeReconnectTimeout.Merge(&dst.NodeReconnectTimeout)
 	src.NodeProbeInterval.Merge(&dst.CoordinateUpdateInterval)
+	src.NodeHealthRefreshInterval.Merge(&dst.NodeHealthRefreshInterval)
 	src.HTTPAddr.Merge(&dst.HTTPAddr)
 	src.Token.Merge(&dst.Token)
 	src.Datacenter.Merge(&dst.Datacenter)

--- a/config_test.go
+++ b/config_test.go
@@ -25,6 +25,7 @@ consul_service = "service"
 consul_service_tag = "asdf"
 consul_kv_path = "custom-esm/"
 node_reconnect_timeout = "22s"
+node_health_refresh_interval = "23s"
 node_probe_interval = "12s"
 external_node_meta {
 	a = "1"
@@ -75,14 +76,15 @@ log_json = true
 `)
 
 	expected := &Config{
-		LogLevel:                 "INFO",
-		EnableDebug:              true,
-		InstanceID:               "test-instance-id",
-		Service:                  "service",
-		Tag:                      "asdf",
-		KVPath:                   "custom-esm/",
-		NodeReconnectTimeout:     22 * time.Second,
-		CoordinateUpdateInterval: 12 * time.Second,
+		LogLevel:                  "INFO",
+		EnableDebug:               true,
+		InstanceID:                "test-instance-id",
+		Service:                   "service",
+		Tag:                       "asdf",
+		KVPath:                    "custom-esm/",
+		NodeReconnectTimeout:      22 * time.Second,
+		NodeHealthRefreshInterval: 23 * time.Second,
+		CoordinateUpdateInterval:  12 * time.Second,
 		NodeMeta: map[string]string{
 			"a": "1",
 			"b": "2",


### PR DESCRIPTION
I am working on a project where several nodes come and go pretty fast, was testing `consul-esm` reaping functionality an saw that the de-registering is only triggered after two health status updates, the first one that sets it to critical, and then it waits for a second one to trigger the de-registering. To speed this up I needed `NodeHealthRefreshInterval` to be configurable.

This change makes it configurable while maintaining the default value it had before it also adds some documentation explaining this 'use case'.