### PR TITLE
[Enhancement] Add logging configuration options to support log file

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,11 +27,15 @@ const (
 )
 
 type Config struct {
-	LogLevel       string
-	EnableDebug    bool
-	EnableSyslog   bool
-	SyslogFacility string
-	LogJSON        bool
+	LogLevel          string
+	EnableDebug       bool
+	EnableSyslog      bool
+	SyslogFacility    string
+	LogJSON           bool
+	LogFile           string
+	LogRotateBytes    int
+	LogRotateMaxFiles int
+	LogRotateDuration time.Duration
 
 	Partition string
 	Service   string
@@ -134,6 +138,10 @@ func DefaultConfig() (*Config, error) {
 		PingType:                  PingTypeUDP,
 		DisableCoordinateUpdates:  false,
 		Partition:                 "",
+		LogFile:                   "",
+		LogRotateBytes:            0,
+		LogRotateMaxFiles:         0,
+		LogRotateDuration:         0,
 	}, nil
 }
 
@@ -165,11 +173,15 @@ type Telemetry struct {
 
 // HumanConfig contains configuration that the practitioner can set
 type HumanConfig struct {
-	LogLevel       flags.StringValue `mapstructure:"log_level"`
-	EnableDebug    flags.BoolValue   `mapstructure:"enable_debug"`
-	EnableSyslog   flags.BoolValue   `mapstructure:"enable_syslog"`
-	SyslogFacility flags.StringValue `mapstructure:"syslog_facility"`
-	LogJSON        flags.BoolValue   `mapstructure:"log_json"`
+	LogLevel          flags.StringValue   `mapstructure:"log_level"`
+	EnableDebug       flags.BoolValue     `mapstructure:"enable_debug"`
+	EnableSyslog      flags.BoolValue     `mapstructure:"enable_syslog"`
+	SyslogFacility    flags.StringValue   `mapstructure:"syslog_facility"`
+	LogJSON           flags.BoolValue     `mapstructure:"log_json"`
+	LogFile           flags.StringValue   `mapstructure:"log_file"`
+	LogRotateBytes    intValue            `mapstructure:"log_rotate_bytes"`
+	LogRotateMaxFiles intValue            `mapstructure:"log_rotate_max_files"`
+	LogRotateDuration flags.DurationValue `mapstructure:"log_rotate_duration"`
 
 	InstanceID flags.StringValue   `mapstructure:"instance_id"`
 	Service    flags.StringValue   `mapstructure:"consul_service"`
@@ -502,5 +514,10 @@ func MergeConfig(dst *Config, src *HumanConfig) error {
 
 	src.PassingThreshold.Merge(&dst.PassingThreshold)
 	src.CriticalThreshold.Merge(&dst.CriticalThreshold)
+
+	src.LogFile.Merge(&dst.LogFile)
+	src.LogRotateBytes.Merge(&dst.LogRotateBytes)
+	src.LogRotateMaxFiles.Merge(&dst.LogRotateMaxFiles)
+	src.LogRotateDuration.Merge(&dst.LogRotateDuration)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -6,16 +6,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/hashicorp/consul-esm/version"
+	"github.com/hashicorp/consul/logging"
+	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/cli"
 	"io"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
-
-	"github.com/hashicorp/consul-esm/version"
-	"github.com/hashicorp/consul/logging"
-	"github.com/hashicorp/go-hclog"
-	"github.com/mitchellh/cli"
 )
 
 const (
@@ -65,11 +64,15 @@ func main() {
 
 	// Set up logging.
 	logConfig := logging.Config{
-		Name:           "consul-esm",
-		LogLevel:       config.LogLevel,
-		EnableSyslog:   config.EnableSyslog,
-		SyslogFacility: config.SyslogFacility,
-		LogJSON:        config.LogJSON,
+		Name:              "consul-esm",
+		LogLevel:          config.LogLevel,
+		EnableSyslog:      config.EnableSyslog,
+		SyslogFacility:    config.SyslogFacility,
+		LogJSON:           config.LogJSON,
+		LogFilePath:       config.LogFile,
+		LogRotateBytes:    config.LogRotateBytes,
+		LogRotateMaxFiles: config.LogRotateMaxFiles,
+		LogRotateDuration: config.LogRotateDuration,
 	}
 	logger, err := logging.Setup(logConfig, os.Stdout)
 	if err != nil {


### PR DESCRIPTION
Description

Consul ESM currently only has the option to log to stdout 
https://github.com/hashicorp/consul-esm/blob/main/main.go#L67-L73

The request is to be able to log to file and configure rotation similar to Consul itself. 

Example in Consul https://github.com/hashicorp/consul/blob/main/logging/logfile.go