### PR TITLE
ESM functional telemetry support

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -15,8 +15,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/armon/go-metrics/prometheus"
-	promsink "github.com/armon/go-metrics/prometheus"
+	prommetrics "github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/consul-esm/version"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -49,14 +48,14 @@ var (
 	maximumTransactionSize = 64
 )
 
-var AgentGauges = []promsink.GaugeDefinition{
+var AgentGauges = []prommetrics.GaugeDefinition{
 	{
 		Name: []string{"esm", "agent", "isLeader"},
 		Help: "Indicates if this ESM instance is the current cluster leader (1 for leader, 0 for follower)",
 	},
 }
 
-var MonitoredGauges = []promsink.GaugeDefinition{
+var MonitoredGauges = []prommetrics.GaugeDefinition{
 	{
 		Name: []string{"esm", "nodes", "monitored"},
 		Help: "Number of external nodes being monitored by this ESM instance",
@@ -100,17 +99,17 @@ type Agent struct {
 }
 
 // Can add counter and histogram definitions here if needed
-func getPrometheusDefs(config *Config) ([]prometheus.GaugeDefinition, []prometheus.SummaryDefinition) {
-	var gauges = [][]prometheus.GaugeDefinition{
+func getPrometheusDefs(config *Config) ([]prommetrics.GaugeDefinition, []prommetrics.SummaryDefinition) {
+	var gauges = [][]prommetrics.GaugeDefinition{
 		AgentGauges,
 		MonitoredGauges,
 		LeaderGauges,
 	}
 
 	// Flatten definitions and apply prefix
-	var gaugeDefs []prometheus.GaugeDefinition
+	var gaugeDefs []prommetrics.GaugeDefinition
 	for _, g := range gauges {
-		var withPrefix []prometheus.GaugeDefinition
+		var withPrefix []prommetrics.GaugeDefinition
 		for _, gauge := range g {
 			if config.Telemetry.MetricsPrefix != "" {
 				gauge.Name = append([]string{config.Telemetry.MetricsPrefix}, gauge.Name...)
@@ -120,12 +119,12 @@ func getPrometheusDefs(config *Config) ([]prometheus.GaugeDefinition, []promethe
 		gaugeDefs = append(gaugeDefs, withPrefix...)
 	}
 
-	var summaries = [][]prometheus.SummaryDefinition{
+	var summaries = [][]prommetrics.SummaryDefinition{
 		ChecksSummary,
 	}
-	var summaryDefs []prometheus.SummaryDefinition
+	var summaryDefs []prommetrics.SummaryDefinition
 	for _, s := range summaries {
-		var withPrefix []prometheus.SummaryDefinition
+		var withPrefix []prommetrics.SummaryDefinition
 		for _, summary := range s {
 			if config.Telemetry.MetricsPrefix != "" {
 				summary.Name = append([]string{config.Telemetry.MetricsPrefix}, summary.Name...)

--- a/agent.go
+++ b/agent.go
@@ -773,7 +773,7 @@ func (a *Agent) kvNodeListPath() string {
 }
 
 func (a *Agent) recordHealthCheckMetrics(start time.Time, nodes map[string]bool, checks api.HealthChecks) {
-	metrics.MeasureSince([]string{"esm", "checks", "execution", "duration"}, start)
+	metrics.MeasureSince([]string{"esm", "checks", "fetch_and_update", "duration"}, start)
 	a.updateCheckMetrics(checks)
 	a.updateServiceMetrics(nodes, checks)
 }

--- a/agent.go
+++ b/agent.go
@@ -14,11 +14,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/prometheus"
+	promsink "github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/consul-esm/version"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/go-hclog"
-	"github.com/prometheus/client_golang/prometheus"
+	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -45,6 +48,24 @@ var (
 	// Specifies the maximum transaction size for kv store ops
 	maximumTransactionSize = 64
 )
+
+var AgentGauges = []promsink.GaugeDefinition{
+	{
+		Name: []string{"esm", "agent", "isLeader"},
+		Help: "Indicates if this ESM instance is the current cluster leader (1 for leader, 0 for follower)",
+	},
+}
+
+var MonitoredGauges = []promsink.GaugeDefinition{
+	{
+		Name: []string{"esm", "nodes", "monitored"},
+		Help: "Number of external nodes being monitored by this ESM instance",
+	},
+	{
+		Name: []string{"esm", "services", "monitored"},
+		Help: "Number of external services being monitored by this ESM instance",
+	},
+}
 
 type lastKnownStatus struct {
 	status string
@@ -78,6 +99,45 @@ type Agent struct {
 	metrics *lib.MetricsConfig
 }
 
+// Can add counter and histogram definitions here if needed
+func getPrometheusDefs(config *Config) ([]prometheus.GaugeDefinition, []prometheus.SummaryDefinition) {
+	var gauges = [][]prometheus.GaugeDefinition{
+		AgentGauges,
+		MonitoredGauges,
+		LeaderGauges,
+	}
+
+	// Flatten definitions and apply prefix
+	var gaugeDefs []prometheus.GaugeDefinition
+	for _, g := range gauges {
+		var withPrefix []prometheus.GaugeDefinition
+		for _, gauge := range g {
+			if config.Telemetry.MetricsPrefix != "" {
+				gauge.Name = append([]string{config.Telemetry.MetricsPrefix}, gauge.Name...)
+			}
+			withPrefix = append(withPrefix, gauge)
+		}
+		gaugeDefs = append(gaugeDefs, withPrefix...)
+	}
+
+	var summaries = [][]prometheus.SummaryDefinition{
+		ChecksSummary,
+	}
+	var summaryDefs []prometheus.SummaryDefinition
+	for _, s := range summaries {
+		var withPrefix []prometheus.SummaryDefinition
+		for _, summary := range s {
+			if config.Telemetry.MetricsPrefix != "" {
+				summary.Name = append([]string{config.Telemetry.MetricsPrefix}, summary.Name...)
+			}
+			withPrefix = append(withPrefix, summary)
+		}
+		summaryDefs = append(summaryDefs, withPrefix...)
+	}
+
+	return gaugeDefs, summaryDefs
+}
+
 func NewAgent(config *Config, logger hclog.Logger) (*Agent, error) {
 	clientConf := config.ClientConfig()
 	client, err := api.NewClient(clientConf)
@@ -85,6 +145,9 @@ func NewAgent(config *Config, logger hclog.Logger) (*Agent, error) {
 		return nil, err
 	}
 
+	gauges, summaries := getPrometheusDefs(config)
+	config.Telemetry.PrometheusOpts.GaugeDefinitions = gauges
+	config.Telemetry.PrometheusOpts.SummaryDefinitions = summaries
 	// Never used locally. I think we keep the reference to avoid GC.
 	metricsConf, err := lib.InitTelemetry(config.Telemetry, logger)
 	if err != nil {
@@ -116,6 +179,8 @@ func NewAgent(config *Config, logger hclog.Logger) (*Agent, error) {
 
 		time.Sleep(retryTime)
 	}
+
+	metrics.SetGauge([]string{"esm", "agent", "isLeader"}, 0)
 
 	return &agent, nil
 }
@@ -394,7 +459,7 @@ func (a *Agent) runHTTP() {
 			}),
 			ErrorHandling: promhttp.ContinueOnError,
 		}
-		mux.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, handlerOptions))
+		mux.Handle("/metrics", promhttp.HandlerFor(promclient.DefaultGatherer, handlerOptions))
 	}
 
 	if a.config.EnableDebug {
@@ -708,6 +773,12 @@ func (a *Agent) kvNodeListPath() string {
 	return a.config.KVPath + "agents/"
 }
 
+func (a *Agent) recordHealthCheckMetrics(start time.Time, nodes map[string]bool, checks api.HealthChecks) {
+	metrics.MeasureSince([]string{"esm", "checks", "execution", "duration"}, start)
+	a.updateCheckMetrics(checks)
+	a.updateServiceMetrics(nodes, checks)
+}
+
 // watchHealthChecks does a blocking query to the Consul api to get
 // all health checks on nodes marked with the external node metadata
 // identifier and sends any updates through the given updateCh.
@@ -748,8 +819,11 @@ func (a *Agent) watchHealthChecks(nodeListCh chan map[string]bool) {
 			// Sleep here to limit how much load we put on the Consul servers.
 		}
 		if len(ourNodes) == 0 {
+			metrics.SetGauge([]string{"esm", "nodes", "monitored"}, 0)
 			continue
 		}
+
+		start := time.Now()
 
 		ourChecks, lastIndex := a.getHealthChecks(waitIndex, ourNodes)
 		if len(ourChecks) == 0 {
@@ -758,6 +832,8 @@ func (a *Agent) watchHealthChecks(nodeListCh chan map[string]bool) {
 
 		waitIndex = lastIndex
 		a.checkRunner.UpdateChecks(ourChecks)
+
+		a.recordHealthCheckMetrics(start, ourNodes, ourChecks)
 
 		if checkCount != len(ourChecks) {
 			checkCount = len(ourChecks)
@@ -958,4 +1034,32 @@ func containsService(serviceID string, services []*api.CatalogService) bool {
 		}
 	}
 	return false
+}
+
+// Add this new method to the Agent struct
+func (a *Agent) updateCheckMetrics(checks api.HealthChecks) {
+	healthyCount := 0
+
+	for _, check := range checks {
+		if check.Status == api.HealthPassing {
+			healthyCount++
+		}
+	}
+
+	metrics.SetGauge([]string{"esm", "checks", "count"}, float32(len(checks)))
+	metrics.SetGauge([]string{"esm", "checks", "healthy"}, float32(healthyCount))
+	metrics.SetGauge([]string{"esm", "checks", "unhealthy"}, float32(len(checks)-healthyCount))
+}
+
+func (a *Agent) updateServiceMetrics(nodes map[string]bool, checks api.HealthChecks) {
+	monitoredServices := make(map[string]struct{})
+	for _, check := range checks {
+		if check.ServiceID != "" {
+			serviceKey := check.Node + ":" + check.ServiceID
+			monitoredServices[serviceKey] = struct{}{}
+		}
+	}
+
+	metrics.SetGauge([]string{"esm", "nodes", "monitored"}, float32(len(nodes)))
+	metrics.SetGauge([]string{"esm", "services", "monitored"}, float32(len(monitoredServices)))
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -940,7 +940,6 @@ func TestAgent_recordHealthCheckMetrics(t *testing.T) {
 
 		agent.recordHealthCheckMetrics(start, nodes, checks)
 
-		// Use retry to allow metrics to be published
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
@@ -996,12 +995,10 @@ func TestAgent_recordHealthCheckMetrics(t *testing.T) {
 
 		agent.recordHealthCheckMetrics(start, nodes, checks)
 
-		// Use retry to allow metrics to be published
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
 
-			// Use the latest interval (there might be multiple from global metrics)
 			intv := intervals[len(intervals)-1]
 
 			countKey := "consul-esm.esm.checks.count"
@@ -1018,8 +1015,6 @@ func TestAgent_recordHealthCheckMetrics(t *testing.T) {
 }
 
 func TestAgent_updateCheckMetrics(t *testing.T) {
-	// Not running in parallel to avoid global metrics conflicts
-
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   "consul-esm",
 		Level:  hclog.LevelFromString("INFO"),
@@ -1041,12 +1036,11 @@ func TestAgent_updateCheckMetrics(t *testing.T) {
 		}
 
 		agent.updateCheckMetrics(checks)
-		time.Sleep(100 * time.Millisecond) // Allow metrics to be published
 
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
-			intv := intervals[len(intervals)-1] // Use the latest interval
+			intv := intervals[len(intervals)-1]
 
 			countKey := "consul-esm.esm.checks.count"
 			countMetric, ok := intv.Gauges[countKey]
@@ -1077,7 +1071,7 @@ func TestAgent_updateCheckMetrics(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
-			intv := intervals[len(intervals)-1] // Use the latest interval
+			intv := intervals[len(intervals)-1]
 
 			countKey := "consul-esm.esm.checks.count"
 			countMetric, ok := intv.Gauges[countKey]
@@ -1104,7 +1098,7 @@ func TestAgent_updateCheckMetrics(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
-			intv := intervals[len(intervals)-1] // Use the latest interval
+			intv := intervals[len(intervals)-1]
 
 			countKey := "consul-esm.esm.checks.count"
 			countMetric, ok := intv.Gauges[countKey]
@@ -1125,7 +1119,6 @@ func TestAgent_updateCheckMetrics(t *testing.T) {
 }
 
 func TestAgent_updateServiceMetrics(t *testing.T) {
-	// Not running in parallel to avoid global metrics conflicts
 
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   "consul-esm",
@@ -1157,7 +1150,7 @@ func TestAgent_updateServiceMetrics(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
-			intv := intervals[len(intervals)-1] // Use the latest interval
+			intv := intervals[len(intervals)-1]
 
 			nodesKey := "consul-esm.esm.nodes.monitored"
 			nodesMetric, ok := intv.Gauges[nodesKey]
@@ -1182,7 +1175,7 @@ func TestAgent_updateServiceMetrics(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
-			intv := intervals[len(intervals)-1] // Use the latest interval
+			intv := intervals[len(intervals)-1]
 
 			nodesKey := "consul-esm.esm.nodes.monitored"
 			nodesMetric, ok := intv.Gauges[nodesKey]
@@ -1204,7 +1197,7 @@ func TestAgent_updateServiceMetrics(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
-			intv := intervals[len(intervals)-1] // Use the latest interval
+			intv := intervals[len(intervals)-1]
 
 			nodesKey := "consul-esm.esm.nodes.monitored"
 			nodesMetric, ok := intv.Gauges[nodesKey]
@@ -1235,7 +1228,7 @@ func TestAgent_updateServiceMetrics(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
-			intv := intervals[len(intervals)-1] // Use the latest interval
+			intv := intervals[len(intervals)-1]
 
 			nodesKey := "consul-esm.esm.nodes.monitored"
 			nodesMetric, ok := intv.Gauges[nodesKey]
@@ -1267,7 +1260,7 @@ func TestAgent_updateServiceMetrics(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			intervals := sink.Data()
 			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
-			intv := intervals[len(intervals)-1] // Use the latest interval
+			intv := intervals[len(intervals)-1]
 
 			nodesKey := "consul-esm.esm.nodes.monitored"
 			nodesMetric, ok := intv.Gauges[nodesKey]

--- a/agent_test.go
+++ b/agent_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,16 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
+
+func setupMetricsSink() *metrics.InmemSink {
+	interval := 1 * time.Second
+	retention := 10 * time.Second
+	sink := metrics.NewInmemSink(interval, retention)
+	cfg := metrics.DefaultConfig("consul-esm")
+	cfg.EnableHostname = false
+	metrics.NewGlobal(cfg, sink)
+	return sink
+}
 
 func testAgent(t *testing.T, cb func(*Config)) *Agent {
 	logger := hclog.New(&hclog.LoggerOptions{
@@ -902,4 +913,482 @@ func TestAgent_ConsulQueryOptions(t *testing.T) {
 			assert.Equal(t, tc.expected, opts.Partition)
 		})
 	}
+}
+
+func TestAgent_recordHealthCheckMetrics(t *testing.T) {
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:            "consul-esm",
+		Level:           hclog.LevelFromString("INFO"),
+		IncludeLocation: true,
+		Output:          LOGOUT,
+	})
+
+	conf, err := DefaultConfig()
+	require.NoError(t, err)
+
+	agent := &Agent{
+		config: conf,
+		logger: logger,
+	}
+
+	t.Run("handles empty inputs gracefully", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		start := time.Now()
+		nodes := map[string]bool{}
+		checks := api.HealthChecks{}
+
+		agent.recordHealthCheckMetrics(start, nodes, checks)
+
+		// Use retry to allow metrics to be published
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+
+			// Use the latest interval (there might be multiple from global metrics)
+			intv := intervals[len(intervals)-1]
+
+			durationKey := "consul-esm.esm.checks.execution.duration"
+			_, ok := intv.Samples[durationKey]
+			require.True(r, ok, fmt.Sprintf("did not find duration sample %q", durationKey))
+
+			countKey := "consul-esm.esm.checks.count"
+			countMetric, ok := intv.Gauges[countKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", countKey))
+			require.Equal(r, float32(0), countMetric.Value)
+
+			healthyKey := "consul-esm.esm.checks.healthy"
+			healthyMetric, ok := intv.Gauges[healthyKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", healthyKey))
+			require.Equal(r, float32(0), healthyMetric.Value)
+
+			unhealthyKey := "consul-esm.esm.checks.unhealthy"
+			unhealthyMetric, ok := intv.Gauges[unhealthyKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", unhealthyKey))
+			require.Equal(r, float32(0), unhealthyMetric.Value)
+
+			nodesKey := "consul-esm.esm.nodes.monitored"
+			nodesMetric, ok := intv.Gauges[nodesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", nodesKey))
+			require.Equal(r, float32(0), nodesMetric.Value)
+
+			servicesKey := "consul-esm.esm.services.monitored"
+			servicesMetric, ok := intv.Gauges[servicesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", servicesKey))
+			require.Equal(r, float32(0), servicesMetric.Value)
+		})
+	})
+
+	t.Run("handles duplicate service IDs correctly", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		start := time.Now()
+		nodes := map[string]bool{
+			"node1": true,
+			"node2": true,
+		}
+		checks := api.HealthChecks{
+			{Node: "node1", ServiceID: "web", Status: api.HealthPassing},
+			{Node: "node1", ServiceID: "web", Status: api.HealthPassing},
+			{Node: "node2", ServiceID: "web", Status: api.HealthCritical},
+			{Node: "node2", ServiceID: "", Status: api.HealthPassing},
+		}
+
+		agent.recordHealthCheckMetrics(start, nodes, checks)
+
+		// Use retry to allow metrics to be published
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+
+			// Use the latest interval (there might be multiple from global metrics)
+			intv := intervals[len(intervals)-1]
+
+			countKey := "consul-esm.esm.checks.count"
+			countMetric, ok := intv.Gauges[countKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", countKey))
+			require.Equal(r, float32(4), countMetric.Value)
+
+			servicesKey := "consul-esm.esm.services.monitored"
+			servicesMetric, ok := intv.Gauges[servicesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", servicesKey))
+			require.Equal(r, float32(2), servicesMetric.Value)
+		})
+	})
+}
+
+func TestAgent_updateCheckMetrics(t *testing.T) {
+	// Not running in parallel to avoid global metrics conflicts
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:   "consul-esm",
+		Level:  hclog.LevelFromString("INFO"),
+		Output: LOGOUT,
+	})
+
+	agent := &Agent{
+		logger: logger,
+	}
+
+	t.Run("calculates check counts correctly", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		checks := api.HealthChecks{
+			{Status: api.HealthPassing},
+			{Status: api.HealthPassing},
+			{Status: api.HealthCritical},
+			{Status: api.HealthWarning},
+		}
+
+		agent.updateCheckMetrics(checks)
+		time.Sleep(100 * time.Millisecond) // Allow metrics to be published
+
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+			intv := intervals[len(intervals)-1] // Use the latest interval
+
+			countKey := "consul-esm.esm.checks.count"
+			countMetric, ok := intv.Gauges[countKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", countKey))
+			require.Equal(r, float32(4), countMetric.Value)
+
+			// Check healthy count (passing)
+			healthyKey := "consul-esm.esm.checks.healthy"
+			healthyMetric, ok := intv.Gauges[healthyKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", healthyKey))
+			require.Equal(r, float32(2), healthyMetric.Value)
+
+			// Check unhealthy count (critical + warning)
+			unhealthyKey := "consul-esm.esm.checks.unhealthy"
+			unhealthyMetric, ok := intv.Gauges[unhealthyKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", unhealthyKey))
+			require.Equal(r, float32(2), unhealthyMetric.Value)
+		})
+	})
+
+	t.Run("handles empty check list", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		checks := api.HealthChecks{}
+
+		agent.updateCheckMetrics(checks)
+
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+			intv := intervals[len(intervals)-1] // Use the latest interval
+
+			countKey := "consul-esm.esm.checks.count"
+			countMetric, ok := intv.Gauges[countKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", countKey))
+			require.Equal(r, float32(0), countMetric.Value)
+
+			healthyKey := "consul-esm.esm.checks.healthy"
+			healthyMetric, ok := intv.Gauges[healthyKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", healthyKey))
+			require.Equal(r, float32(0), healthyMetric.Value)
+
+			unhealthyKey := "consul-esm.esm.checks.unhealthy"
+			unhealthyMetric, ok := intv.Gauges[unhealthyKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", unhealthyKey))
+			require.Equal(r, float32(0), unhealthyMetric.Value)
+		})
+	})
+
+	t.Run("handles nil check list", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		agent.updateCheckMetrics(nil)
+
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+			intv := intervals[len(intervals)-1] // Use the latest interval
+
+			countKey := "consul-esm.esm.checks.count"
+			countMetric, ok := intv.Gauges[countKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", countKey))
+			require.Equal(r, float32(0), countMetric.Value)
+
+			healthyKey := "consul-esm.esm.checks.healthy"
+			healthyMetric, ok := intv.Gauges[healthyKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", healthyKey))
+			require.Equal(r, float32(0), healthyMetric.Value)
+
+			unhealthyKey := "consul-esm.esm.checks.unhealthy"
+			unhealthyMetric, ok := intv.Gauges[unhealthyKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", unhealthyKey))
+			require.Equal(r, float32(0), unhealthyMetric.Value)
+		})
+	})
+}
+
+func TestAgent_updateServiceMetrics(t *testing.T) {
+	// Not running in parallel to avoid global metrics conflicts
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:   "consul-esm",
+		Level:  hclog.LevelFromString("INFO"),
+		Output: LOGOUT,
+	})
+
+	agent := &Agent{
+		logger: logger,
+	}
+
+	t.Run("counts unique services correctly", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		nodes := map[string]bool{
+			"node1": true,
+			"node2": true,
+		}
+
+		checks := api.HealthChecks{
+			{Node: "node1", ServiceID: "service1"},
+			{Node: "node1", ServiceID: "service1"}, // Duplicate
+			{Node: "node2", ServiceID: "service2"},
+			{Node: "node2", ServiceID: ""}, // No service
+		}
+
+		agent.updateServiceMetrics(nodes, checks)
+
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+			intv := intervals[len(intervals)-1] // Use the latest interval
+
+			nodesKey := "consul-esm.esm.nodes.monitored"
+			nodesMetric, ok := intv.Gauges[nodesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", nodesKey))
+			require.Equal(r, float32(2), nodesMetric.Value)
+
+			servicesKey := "consul-esm.esm.services.monitored"
+			servicesMetric, ok := intv.Gauges[servicesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", servicesKey))
+			require.Equal(r, float32(2), servicesMetric.Value)
+		})
+	})
+
+	t.Run("handles empty inputs", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		nodes := map[string]bool{}
+		checks := api.HealthChecks{}
+
+		agent.updateServiceMetrics(nodes, checks)
+
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+			intv := intervals[len(intervals)-1] // Use the latest interval
+
+			nodesKey := "consul-esm.esm.nodes.monitored"
+			nodesMetric, ok := intv.Gauges[nodesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", nodesKey))
+			require.Equal(r, float32(0), nodesMetric.Value)
+
+			servicesKey := "consul-esm.esm.services.monitored"
+			servicesMetric, ok := intv.Gauges[servicesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", servicesKey))
+			require.Equal(r, float32(0), servicesMetric.Value)
+		})
+	})
+
+	t.Run("handles nil inputs", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		agent.updateServiceMetrics(nil, nil)
+
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+			intv := intervals[len(intervals)-1] // Use the latest interval
+
+			nodesKey := "consul-esm.esm.nodes.monitored"
+			nodesMetric, ok := intv.Gauges[nodesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", nodesKey))
+			require.Equal(r, float32(0), nodesMetric.Value)
+
+			servicesKey := "consul-esm.esm.services.monitored"
+			servicesMetric, ok := intv.Gauges[servicesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", servicesKey))
+			require.Equal(r, float32(0), servicesMetric.Value)
+		})
+	})
+
+	t.Run("handles checks without services", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		nodes := map[string]bool{
+			"node1": true,
+		}
+
+		checks := api.HealthChecks{
+			{Node: "node1", ServiceID: ""},
+			{Node: "node1", ServiceID: ""},
+		}
+
+		agent.updateServiceMetrics(nodes, checks)
+
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+			intv := intervals[len(intervals)-1] // Use the latest interval
+
+			nodesKey := "consul-esm.esm.nodes.monitored"
+			nodesMetric, ok := intv.Gauges[nodesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", nodesKey))
+			require.Equal(r, float32(1), nodesMetric.Value)
+
+			servicesKey := "consul-esm.esm.services.monitored"
+			servicesMetric, ok := intv.Gauges[servicesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", servicesKey))
+			require.Equal(r, float32(0), servicesMetric.Value)
+		})
+	})
+
+	t.Run("handles same service on different nodes", func(t *testing.T) {
+		sink := setupMetricsSink()
+
+		nodes := map[string]bool{
+			"node1": true,
+			"node2": true,
+		}
+
+		checks := api.HealthChecks{
+			{Node: "node1", ServiceID: "web"},
+			{Node: "node2", ServiceID: "web"},
+		}
+
+		agent.updateServiceMetrics(nodes, checks)
+
+		retry.Run(t, func(r *retry.R) {
+			intervals := sink.Data()
+			require.NotEmpty(r, intervals, "Expected at least one metrics interval")
+			intv := intervals[len(intervals)-1] // Use the latest interval
+
+			nodesKey := "consul-esm.esm.nodes.monitored"
+			nodesMetric, ok := intv.Gauges[nodesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", nodesKey))
+			require.Equal(r, float32(2), nodesMetric.Value)
+
+			servicesKey := "consul-esm.esm.services.monitored"
+			servicesMetric, ok := intv.Gauges[servicesKey]
+			require.True(r, ok, fmt.Sprintf("did not find the key %q", servicesKey))
+			require.Equal(r, float32(2), servicesMetric.Value)
+		})
+	})
+}
+
+func TestAgent_getPrometheusDefs(t *testing.T) {
+	t.Run("returns correct definitions without prefix", func(t *testing.T) {
+		config, err := DefaultConfig()
+		require.NoError(t, err)
+		config.Telemetry.MetricsPrefix = ""
+
+		gauges, summaries := getPrometheusDefs(config)
+
+		// Verify we get the expected number of gauge definitions
+		expectedGaugeCount := len(AgentGauges) + len(MonitoredGauges) + len(LeaderGauges)
+		require.Len(t, gauges, expectedGaugeCount, "Should have correct number of gauge definitions")
+
+		// Verify we get the expected number of summary definitions
+		expectedSummaryCount := len(ChecksSummary)
+		require.Len(t, summaries, expectedSummaryCount, "Should have correct number of summary definitions")
+
+		// Check specific gauge definitions are present
+		gaugeNames := make(map[string]bool)
+		for _, gauge := range gauges {
+			gaugeNames[strings.Join(gauge.Name, ".")] = true
+		}
+
+		expectedGauges := []string{
+			"esm.agent.isLeader",
+			"esm.nodes.monitored",
+			"esm.services.monitored",
+			"esm.agents.healthy",
+		}
+
+		for _, expected := range expectedGauges {
+			require.True(t, gaugeNames[expected], "Should contain gauge %s", expected)
+		}
+
+		// Check specific summary definitions are present
+		summaryNames := make(map[string]bool)
+		for _, summary := range summaries {
+			summaryNames[strings.Join(summary.Name, ".")] = true
+		}
+
+		expectedSummaries := []string{
+			"esm.checks.execution.duration",
+		}
+
+		for _, expected := range expectedSummaries {
+			require.True(t, summaryNames[expected], "Should contain summary %s", expected)
+		}
+	})
+
+	t.Run("applies metrics prefix correctly", func(t *testing.T) {
+		config, err := DefaultConfig()
+		require.NoError(t, err)
+		config.Telemetry.MetricsPrefix = "test-prefix"
+
+		gauges, summaries := getPrometheusDefs(config)
+
+		// Verify all gauges have the prefix
+		for _, gauge := range gauges {
+			require.True(t, len(gauge.Name) > 0, "Gauge should have a name")
+			require.Equal(t, "test-prefix", gauge.Name[0], "Gauge should start with metrics prefix")
+		}
+
+		// Verify all summaries have the prefix
+		for _, summary := range summaries {
+			require.True(t, len(summary.Name) > 0, "Summary should have a name")
+			require.Equal(t, "test-prefix", summary.Name[0], "Summary should start with metrics prefix")
+		}
+	})
+
+	t.Run("handles empty metrics prefix", func(t *testing.T) {
+		config, err := DefaultConfig()
+		require.NoError(t, err)
+		config.Telemetry.MetricsPrefix = ""
+
+		gauges, summaries := getPrometheusDefs(config)
+
+		// Verify gauges don't have unexpected prefixes
+		for _, gauge := range gauges {
+			require.True(t, len(gauge.Name) > 0, "Gauge should have a name")
+			require.Equal(t, "esm", gauge.Name[0], "Gauge should start with 'esm' when no prefix is set")
+		}
+
+		// Verify summaries don't have unexpected prefixes
+		for _, summary := range summaries {
+			require.True(t, len(summary.Name) > 0, "Summary should have a name")
+			require.Equal(t, "esm", summary.Name[0], "Summary should start with 'esm' when no prefix is set")
+		}
+	})
+
+	t.Run("gauge definitions have help text", func(t *testing.T) {
+		config, err := DefaultConfig()
+		require.NoError(t, err)
+
+		gauges, _ := getPrometheusDefs(config)
+
+		for _, gauge := range gauges {
+			require.NotEmpty(t, gauge.Help, "Gauge %s should have help text", strings.Join(gauge.Name, "."))
+		}
+	})
+
+	t.Run("summary definitions have help text", func(t *testing.T) {
+		config, err := DefaultConfig()
+		require.NoError(t, err)
+
+		_, summaries := getPrometheusDefs(config)
+
+		for _, summary := range summaries {
+			require.NotEmpty(t, summary.Help, "Summary %s should have help text", strings.Join(summary.Name, "."))
+		}
+	})
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -947,7 +947,7 @@ func TestAgent_recordHealthCheckMetrics(t *testing.T) {
 			// Use the latest interval (there might be multiple from global metrics)
 			intv := intervals[len(intervals)-1]
 
-			durationKey := "consul-esm.esm.checks.execution.duration"
+			durationKey := "consul-esm.esm.checks.fetch_and_update.duration"
 			_, ok := intv.Samples[durationKey]
 			require.True(r, ok, fmt.Sprintf("did not find duration sample %q", durationKey))
 
@@ -1315,7 +1315,7 @@ func TestAgent_getPrometheusDefs(t *testing.T) {
 		}
 
 		expectedSummaries := []string{
-			"esm.checks.execution.duration",
+			"esm.checks.fetch_and_update.duration",
 		}
 
 		for _, expected := range expectedSummaries {

--- a/check.go
+++ b/check.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/prometheus"
 	consulchecks "github.com/hashicorp/consul/agent/checks"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
@@ -26,6 +27,28 @@ const externalCheckName = "externalNodeHealth"
 
 // defaultInterval is the check interval to use if one is not set.
 var defaultInterval = 30 * time.Second
+
+var ChecksGauges = []prometheus.GaugeDefinition{
+	{
+		Name: []string{"esm", "checks"},
+		Help: "Total number of external checks being monitored",
+	},
+	{
+		Name: []string{"esm", "checks", "healthy"},
+		Help: "Number of external checks in passing state",
+	},
+	{
+		Name: []string{"esm", "checks", "unhealthy"},
+		Help: "Number of external checks in unhealthy state",
+	},
+}
+
+var ChecksSummary = []prometheus.SummaryDefinition{
+	{
+		Name: []string{"esm", "checks", "execution", "duration"},
+		Help: "Measures the time taken to execute all health checks in seconds",
+	},
+}
 
 type checkIDSet map[types.CheckID]bool
 

--- a/check.go
+++ b/check.go
@@ -46,7 +46,7 @@ var ChecksGauges = []prometheus.GaugeDefinition{
 var ChecksSummary = []prometheus.SummaryDefinition{
 	{
 		Name: []string{"esm", "checks", "execution", "duration"},
-		Help: "Measures the time taken to execute all health checks in seconds",
+		Help: "Measures the time taken to execute all health checks",
 	},
 }
 

--- a/check.go
+++ b/check.go
@@ -45,8 +45,8 @@ var ChecksGauges = []prometheus.GaugeDefinition{
 
 var ChecksSummary = []prometheus.SummaryDefinition{
 	{
-		Name: []string{"esm", "checks", "execution", "duration"},
-		Help: "Measures the time taken to execute all health checks",
+		Name: []string{"esm", "checks", "fetch_and_update", "duration"},
+		Help: "Measures the time taken to fetch and update health checks",
 	},
 }
 

--- a/config.go
+++ b/config.go
@@ -472,8 +472,10 @@ func convertTelemetry(telemetry Telemetry) (lib.TelemetryConfig, error) {
 		MetricsPrefix:                      stringVal(telemetry.MetricsPrefix),
 		StatsdAddr:                         stringVal(telemetry.StatsdAddr),
 		StatsiteAddr:                       stringVal(telemetry.StatsiteAddr),
-		PrometheusOpts: prometheus.PrometheusOpts{Expiration: prometheusRetentionTime,
-			Name: stringVal(telemetry.MetricsPrefix)},
+		PrometheusOpts: prometheus.PrometheusOpts{
+			Expiration: prometheusRetentionTime,
+			Name:       stringVal(telemetry.MetricsPrefix),
+		},
 	}, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -472,7 +472,8 @@ func convertTelemetry(telemetry Telemetry) (lib.TelemetryConfig, error) {
 		MetricsPrefix:                      stringVal(telemetry.MetricsPrefix),
 		StatsdAddr:                         stringVal(telemetry.StatsdAddr),
 		StatsiteAddr:                       stringVal(telemetry.StatsiteAddr),
-		PrometheusOpts:                     prometheus.PrometheusOpts{Expiration: prometheusRetentionTime},
+		PrometheusOpts: prometheus.PrometheusOpts{Expiration: prometheusRetentionTime,
+			Name: stringVal(telemetry.MetricsPrefix)},
 	}, nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -124,7 +124,11 @@ log_json = true
 			BlockedPrefixes:                    []string{"bad", "worse"},
 			MetricsPrefix:                      "test",
 			PrometheusOpts: prometheus.PrometheusOpts{
-				Expiration: 5 * time.Hour,
+				Expiration:         5 * time.Hour,
+				GaugeDefinitions:   []prometheus.GaugeDefinition(nil),
+				SummaryDefinitions: []prometheus.SummaryDefinition(nil),
+				CounterDefinitions: []prometheus.CounterDefinition(nil),
+				Name:               "test",
 			},
 			StatsdAddr:   "example.io:8888",
 			StatsiteAddr: "5.6.7.8",

--- a/leader.go
+++ b/leader.go
@@ -62,9 +62,6 @@ LEADER_WAIT:
 		return
 	default:
 	}
-
-	metrics.SetGauge([]string{"esm", "agent", "isLeader"}, 0)
-
 	// Wait to get the leader lock before running snapshots.
 	a.logger.Info("Trying to obtain leadership...")
 	if lock == nil {


### PR DESCRIPTION
**Description:**
This PR include changes for enhancing Consul ESM telemetry to include functional activity metrics. 

**Proposed Solution:**
By leveraging the go-metrics library, ESM will expose metrics such as leadership status, check counts, monitored nodes/services and healthy esm instances. These metrics will be available via configurable sinks (e.g., Prometheus, StatsD), enabling improved observability, alerting, and operational insights for ESM deployments.

| Metric Name                   | Description                                                     | Unit            | Type    |
|-------------------------------|-----------------------------------------------------------------|-----------------|---------|
| esm.agent.isLeader            | Tracks if an agent is leader or not                             | Number (1 or 0) | Gauge   |
| esm.agents.healthy            | Number of active esm agents                                     | Number          | Gauge   |
| esm.checks                    | Number of checks per agent                                      | Number          | Gauge   |
| esm.checks.healthy            | Number of healthy checks per agent                              | Number          | Gauge   |
| esm.checks.unhealthy          | Number of unhealthy checks per agent                            | Number          | Gauge   |
| esm.nodes.monitored           | Number of monitored nodes per agent                             | Number          | Gauge   |
| esm.services.monitored        | Number of monitored services per agent                          | Number          | Gauge   |
| esm.checks.fetch_and_update.duration | Measures the time taken to fetch and update all health checks | ms/sec         | Summary |

**Configuration**
Add telemetry configuration for esm to have these metrics exposed. 