### PR TITLE
Clarify ping_type behavior in ESM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,17 @@ https_key_file = ""
 // Client address to expose API endpoints. Required in order to expose /metrics endpoint for Prometheus. Example: "127.0.0.1:8080"
 client_address = ""
 
-// The method to use for pinging external nodes. Defaults to "udp" but can
-// also be set to "socket" to use ICMP (which requires root privileges).
+// The method to use for pinging external nodes.
+// - "udp": Uses UDP packets to ping nodes. This method requires both IP and port
+//   to be reachable. In some environments, this may silently fail if the port is 
+//   closed or blocked, resulting in failed or missing health checks.
+//
+// - "socket": Uses ICMP (Internet Control Message Protocol) to ping nodes, similar 
+//   to the `ping` command. This method does not require a port and typically provides 
+//   more reliable results for basic node reachability checks.
+//
+// Defaults to "udp" but can also be set to "socket" to use ICMP
+// (which requires root privileges).
 ping_type = "udp"
 
 // The telemetry configuration which matches Consul's telemetry config options.


### PR DESCRIPTION
Summary

This PR updates the README documentation to clarify the behavior difference between `ping_type = "udp"` and `ping_type = "socket"` in the ESM configuration.

Key Updates

- Describes that `udp` requires both IP and port, and may silently fail in some environments.
- Explains that `socket` uses ICMP and is more reliable for basic node availability.
- Adds usage guidance and default behavior notes.

Testing

- Confirmed that `ping_type = "udp"` does not send pings if port is provided.
- `ping_type = "socket"` correctly sends ICMP pings at configured intervals (`10s`).
