### PR TITLE
fix(agentless): allow disabling check update batching and document ba…

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ disable_coordinate_updates = false
 // Can also be provided through the CONSUL_ENABLEAGENTLESS environment variable.
 enable_agentless = true/false
 
+// Controls how long ESM buffers agentless health check updates before flushing
+// them to Consul in a transaction. This only applies when enable_agentless is
+// true. Use a Go duration such as "100ms", "500ms", or "2s". If unset, ESM
+// uses the default of "500ms". Set this to "0s" to disable buffering.
+batch_flush_interval = "500ms"
+
 // The address of the local Consul agent.
 // or
 // The address of the Consul server to use if `enable_agentless` is set to true.
@@ -306,6 +312,45 @@ critical_threshold = 0
 ```
 
 [HCL]: https://github.com/hashicorp/hcl "HashiCorp Configuration Language (HCL)"
+
+### Batch Flushing for Agentless Check Updates
+
+When `enable_agentless = true`, Consul ESM buffers health check status updates for a
+short period and flushes them to Consul using transactions instead of sending one HTTP
+request per change. This reduces API round-trips and improves throughput when many
+external checks are updating at the same time.
+
+The buffering window is controlled by `batch_flush_interval`.
+
+```hcl
+enable_agentless = true
+http_addr = "consul.service.consul:8500"
+batch_flush_interval = "500ms"
+```
+
+Valid values:
+
+- Any positive [Go duration](https://pkg.go.dev/time#ParseDuration) string such as `50ms`, `250ms`, `1s`, or `2m`
+- If the value is omitted, ESM uses the default `500ms`
+- If the value is `0` or `0s`, ESM disables buffering and sends updates immediately
+- Negative values are not useful; if provided, ESM falls back to the default `500ms`
+
+How it behaves:
+
+- This setting only affects agentless mode; agent-based operation continues to update checks immediately
+- Setting `batch_flush_interval = "0s"` makes agentless mode also update checks immediately
+- Updates for the same check are deduplicated while they are buffered, so only the latest pending state is flushed
+- Buffered updates are flushed when the timer expires or sooner if the transaction reaches Consul's transaction batch limit of 64 operations
+
+Tuning guidance:
+
+- Lower values reduce the time a status update waits before it is written to Consul, but increase HTTP traffic and reduce batching efficiency
+- Higher values improve batching efficiency and can reduce load on Consul servers during bursts, but they add more delay before remote state is written
+- Start with the default `500ms` unless you have measured pressure in one direction or the other
+- Use a lower value if you need faster propagation of status changes and your Consul servers are not under write pressure
+- Use a higher value if you have large numbers of external checks, frequent status churn, or want to reduce transaction volume at the cost of slightly slower visibility
+
+In practice, values in the low hundreds of milliseconds are a good starting point for most deployments. Very small values can make batching ineffective, while very large values can make health status changes appear sluggish.
 
 ### Threshold for Updating Check Status
 

--- a/agentless_optimization_test.go
+++ b/agentless_optimization_test.go
@@ -103,6 +103,22 @@ func TestCheckRunner_BatchingInitialization(t *testing.T) {
 	t.Log("Batching properly initialized for agentless mode with longer interval")
 }
 
+func TestCheckRunner_BatchingDisabledWhenFlushIntervalIsZero(t *testing.T) {
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:   "test",
+		Level:  hclog.LevelFromString("INFO"),
+		Output: LOGOUT,
+	})
+
+	mockClient, _ := api.NewClient(api.DefaultConfig())
+	runner := NewCheckRunner(logger, mockClient, 5*time.Minute, 30*time.Second, &tls.Config{}, 1, 1, true, 0)
+	defer runner.Stop()
+
+	if runner.batcher != nil {
+		t.Fatal("Expected batcher to be nil when batch flush interval is zero")
+	}
+}
+
 // TestCheckRunner_BatchQueueing verifies that check updates are properly queued
 func TestCheckRunner_BatchQueueing(t *testing.T) {
 	logger := hclog.New(&hclog.LoggerOptions{

--- a/check.go
+++ b/check.go
@@ -163,19 +163,22 @@ func NewCheckRunner(logger hclog.Logger, client *api.Client, updateInterval,
 
 	// Only initialize batcher for agentless mode
 	if isAgentless {
-		batchInterval := defaultBatchFlushInterval
-		// Use configured batch flush interval for agentless mode
-		if batchFlushInterval > 0 {
-			batchInterval = batchFlushInterval
+		if batchFlushInterval == 0 {
+			logger.Debug("Agentless batching disabled", "is_agentless", isAgentless)
+		} else {
+			batchInterval := batchFlushInterval
+			if batchInterval < 0 {
+				batchInterval = defaultBatchFlushInterval
+			}
+			logger.Debug("Configuring CheckRunner batch interval", "interval", batchInterval, "is_agentless", isAgentless)
+			// Initialise batcher for agentless mode only
+			runner.batcher = NewCheckUpdateBatcher(BatcherConfig{
+				MaxBatchSize:  maxTxnOps,
+				FlushInterval: batchInterval,
+				Logger:        logger,
+				ProcessFunc:   runner.processBatchedUpdates,
+			})
 		}
-		logger.Debug("Configuring CheckRunner batch interval", "interval", batchInterval, "is_agentless", isAgentless)
-		// Initialise batcher for agentless mode only
-		runner.batcher = NewCheckUpdateBatcher(BatcherConfig{
-			MaxBatchSize:  maxTxnOps,
-			FlushInterval: batchInterval,
-			Logger:        logger,
-			ProcessFunc:   runner.processBatchedUpdates,
-		})
 	}
 
 	return runner


### PR DESCRIPTION
### Summary
This change adds an explicit way to disable agentless check update batching and documents the public configuration for batch_flush_interval.

### Problem
Agentless batching was introduced recently, but there was no public-facing README documentation for:

how to configure batch_flush_interval
what values are valid
how lower or higher values affect behavior
There was also no explicit way to disable batching once enable_agentless = true. A value of 0 fell back to the default flush interval instead of turning batching off.

### Changes
treat batch_flush_interval = 0 as an explicit opt-out for agentless batching
preserve the default 500ms behavior when the setting is omitted
document batch_flush_interval in the README configuration reference
add README guidance for:
default behavior
valid Go duration values
0s disabling buffering
tradeoffs of lower vs higher values
add test coverage for the zero-value behavior
### Behavior After This Change
omitted batch_flush_interval: defaults to 500ms
batch_flush_interval = "0s": disables batching and sends updates immediately
positive duration values: enable batching with the configured flush interval
negative values: continue to fall back to the default interval
Test### ing
added coverage for the zero-value batching behavior
ran the agentless batching test file successfully
