### PR TITLE
ci: add Go test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,21 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         go: [^1]
-    outputs:
-      go-version: ${{ steps.setup-go.outputs.go-version }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        id: setup-go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: ${{ matrix.go }}
 
       - name: Install Consul for integration testing
+        env:
+          # Latest CE version — pinned so CI uses a known-good release.
+          # ENT versions need CONSUL_LICENSE and can't be used here.
+          CONSUL_VERSION: "2.0.0"
         run: |
-          CONSUL_VERSION="2.0.0"
           curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
           unzip -o "consul_${CONSUL_VERSION}_linux_amd64.zip" consul -d /usr/local/bin
           rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
@@ -51,5 +51,4 @@ jobs:
       pull-requests: write
       id-token: write
     with:
-      go-version: ${{ needs.run-tests.outputs.go-version }}
       pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,44 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         go: [^1]
+    outputs:
+      go-version: ${{ steps.setup-go.outputs.go-version }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: ${{ matrix.go }}
 
       - name: Install Consul for integration testing
         run: |
-          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-          sudo apt-get update && sudo apt-get install consul
+          CONSUL_VERSION="2.0.0"
+          curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
+          unzip "consul_${CONSUL_VERSION}_linux_amd64.zip" -d /usr/local/bin
+          rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
+          consul version
 
-      - name: Run tests
-        run: |
-          make test
+      - name: Run tests with coverage
+        run: go test -timeout=60s -p 1 -coverprofile=coverage.txt -covermode=set ./...
+
+      - name: Upload coverage profile
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: esm-coverage
+          path: coverage.txt
+          if-no-files-found: ignore
+
+  coverage-report:
+    needs: [run-tests]
+    uses: ./.github/workflows/reusable-coverage-report.yml
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    with:
+      go-version: ${{ needs.run-tests.outputs.go-version }}
+      pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           CONSUL_VERSION="2.0.0"
           curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
-          unzip "consul_${CONSUL_VERSION}_linux_amd64.zip" -d /usr/local/bin
+          unzip -o "consul_${CONSUL_VERSION}_linux_amd64.zip" consul -d /usr/local/bin
           rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
           consul version
 

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -1,0 +1,204 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Reusable workflow: merges per-module coverage profiles, computes the total,
+# posts/edits a PR comment, uploads an HTML artifact, uploads to Codecov, and
+# (on main) pushes a coverage badge SVG to the `badges` branch for the README.
+
+name: reusable-coverage-report
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+      pr-number:
+        required: false
+        type: string
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # required for OIDC tokenless Codecov upload
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Download coverage profiles
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: '*-coverage'
+          path: coverage-artifacts
+
+      - name: Compute coverage
+        id: coverage
+        run: |
+          PROFILES=$(find coverage-artifacts -name 'coverage.txt' 2>/dev/null | sort)
+          COUNT=$(echo "$PROFILES" | grep -c . || true)
+          echo "Found $COUNT coverage profile(s)"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No coverage profiles found"
+            echo "total=N/A" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$COUNT" -eq 1 ]; then
+            cp "$(echo "$PROFILES")" merged-coverage.out
+          else
+            go install github.com/wadey/gocovmerge@b5bfa59ec0ad
+            echo "$PROFILES" | xargs gocovmerge > merged-coverage.out
+          fi
+
+          # Exclude generated mock files and test helper paths.
+          TOTAL=$(awk '
+            /^mode:/ { next }
+            /\/mocks\/|\/mock_/ { next }
+            { stmts += $2; if ($3 > 0) covered += $2 }
+            END { if (stmts > 0) printf "%.1f%%", covered/stmts*100; else print "0.0%" }
+          ' merged-coverage.out)
+          echo "Total coverage: $TOTAL"
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+
+          # Strip excluded lines from profile before generating HTML and per-package summary.
+          grep -v -e '/mocks/' -e '/mock_' merged-coverage.out > filtered-coverage.out || true
+          mv filtered-coverage.out merged-coverage.out
+
+          # Package-level summary.
+          go tool cover -func merged-coverage.out | grep -v '^total:' | \
+            awk '{
+              sub(/^github\.com\/hashicorp\/consul-esm\//, "", $1)
+              split($1, parts, "/")
+              pkg = parts[1]
+              gsub(/:.*/, "", pkg)
+              pct = $NF; gsub(/%/, "", pct)
+              sum[pkg] += pct; n[pkg]++
+            }
+            END {
+              for (pkg in sum) printf "%-40s %.1f%%\n", pkg, sum[pkg]/n[pkg]
+            }' | sort > pkg-summary.txt
+
+          {
+            echo "## Go Test Coverage"
+            echo ""
+            echo "**Total coverage: $TOTAL**"
+            echo ""
+            echo "| Package | Avg Coverage |"
+            echo "|---------|-------------|"
+            while IFS= read -r line; do
+              pkg=$(echo "$line" | awk '{print $1}')
+              pct=$(echo "$line" | awk '{print $2}')
+              echo "| \`$pkg\` | $pct |"
+            done < pkg-summary.txt
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          go tool cover -html=merged-coverage.out -o coverage.html
+
+      - name: Post PR comment
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOTAL: ${{ steps.coverage.outputs.total }}
+        run: |
+          MARKER="<!-- coverage-report-comment -->"
+          BODY=$(cat <<EOF
+          ${MARKER}
+
+          ### Go Test Coverage: **${TOTAL}**
+
+          See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report.
+          EOF
+          )
+
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/${{ inputs.pr-number }}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- coverage-report-comment -->"))) | .id' \
+            | tail -n1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -f body="$BODY"
+          else
+            gh pr comment ${{ inputs.pr-number }} \
+              --repo "${{ github.repository }}" \
+              --body "$BODY"
+          fi
+
+      - name: Upload HTML coverage report
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: coverage-report-html
+          path: |
+            merged-coverage.out
+            coverage.html
+
+      - name: Upload to Codecov
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        with:
+          files: merged-coverage.out
+          use_oidc: true
+          fail_ci_if_error: false
+          verbose: false
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && steps.coverage.outputs.total != 'N/A'
+        env:
+          TOTAL: ${{ steps.coverage.outputs.total }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Generate SVG badge
+          PCT="${TOTAL%%%}"
+          if (( $(echo "$PCT >= 80" | bc -l) )); then COLOR="brightgreen"
+          elif (( $(echo "$PCT >= 60" | bc -l) )); then COLOR="yellow"
+          else COLOR="red"
+          fi
+
+          cat > coverage.svg <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="120" height="20">
+            <linearGradient id="s" x2="0" y2="100%">
+              <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+              <stop offset="1" stop-opacity=".1"/>
+            </linearGradient>
+            <rect rx="3" width="120" height="20" fill="#555"/>
+            <rect rx="3" x="62" width="58" height="20" fill="${COLOR}"/>
+            <rect x="62" width="4" height="20" fill="${COLOR}"/>
+            <rect rx="3" width="120" height="20" fill="url(#s)"/>
+            <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+              <text x="32" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+              <text x="32" y="14">coverage</text>
+              <text x="90" y="15" fill="#010101" fill-opacity=".3">${TOTAL}</text>
+              <text x="90" y="14">${TOTAL}</text>
+            </g>
+          </svg>
+          SVGEOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin badges 2>/dev/null || true
+          if git rev-parse --verify origin/badges >/dev/null 2>&1; then
+            git checkout -B badges origin/badges
+          else
+            git checkout --orphan badges
+            git rm -rf . --quiet || true
+          fi
+
+          mv coverage.svg coverage.svg.tmp
+          git rm -rf . --quiet || true
+          mv coverage.svg.tmp coverage.svg
+
+          git add coverage.svg
+          git commit -m "ci: update coverage badge to ${TOTAL}" || echo "No changes to badge"
+          git push origin badges

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -157,47 +157,60 @@ jobs:
           TOTAL: ${{ steps.coverage.outputs.total }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Generate SVG badge
-          PCT="${TOTAL%%%}"
-          if (( $(echo "$PCT >= 80" | bc -l) )); then COLOR="brightgreen"
-          elif (( $(echo "$PCT >= 60" | bc -l) )); then COLOR="yellow"
-          else COLOR="red"
+          PCT=$(echo "$TOTAL" | tr -d '%')
+          if awk "BEGIN {exit !($PCT >= 75)}"; then COLOR="#4c1"
+          elif awk "BEGIN {exit !($PCT >= 60)}"; then COLOR="#97CA00"
+          elif awk "BEGIN {exit !($PCT >= 40)}"; then COLOR="#dfb317"
+          else COLOR="#e05d44"
           fi
 
-          cat > coverage.svg <<SVGEOF
-          <svg xmlns="http://www.w3.org/2000/svg" width="120" height="20">
+          # Compute dynamic text widths: label "coverage" = 62px, value width ~7px/char
+          LABEL="coverage"
+          LABEL_W=62
+          VAL_LEN=${#TOTAL}
+          VAL_W=$(( VAL_LEN * 7 + 10 ))
+          TOTAL_W=$(( LABEL_W + VAL_W ))
+          LABEL_MID=$(( LABEL_W / 2 + 1 ))
+          VAL_MID=$(( LABEL_W + VAL_W / 2 ))
+
+          cat > /tmp/coverage.svg <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="${TOTAL_W}" height="20">
             <linearGradient id="s" x2="0" y2="100%">
               <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
               <stop offset="1" stop-opacity=".1"/>
             </linearGradient>
-            <rect rx="3" width="120" height="20" fill="#555"/>
-            <rect rx="3" x="62" width="58" height="20" fill="${COLOR}"/>
-            <rect x="62" width="4" height="20" fill="${COLOR}"/>
-            <rect rx="3" width="120" height="20" fill="url(#s)"/>
+            <rect rx="3" width="${TOTAL_W}" height="20" fill="#555"/>
+            <rect rx="3" x="${LABEL_W}" width="${VAL_W}" height="20" fill="${COLOR}"/>
+            <rect x="${LABEL_W}" width="4" height="20" fill="${COLOR}"/>
+            <rect rx="3" width="${TOTAL_W}" height="20" fill="url(#s)"/>
             <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-              <text x="32" y="15" fill="#010101" fill-opacity=".3">coverage</text>
-              <text x="32" y="14">coverage</text>
-              <text x="90" y="15" fill="#010101" fill-opacity=".3">${TOTAL}</text>
-              <text x="90" y="14">${TOTAL}</text>
+              <text x="${LABEL_MID}" y="15" fill="#010101" fill-opacity=".3">${LABEL}</text>
+              <text x="${LABEL_MID}" y="14">${LABEL}</text>
+              <text x="${VAL_MID}" y="15" fill="#010101" fill-opacity=".3">${TOTAL}</text>
+              <text x="${VAL_MID}" y="14">${TOTAL}</text>
             </g>
           </svg>
           SVGEOF
 
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-          git fetch origin badges 2>/dev/null || true
-          if git rev-parse --verify origin/badges >/dev/null 2>&1; then
-            git checkout -B badges origin/badges
+          if git ls-remote --exit-code origin badges >/dev/null 2>&1; then
+            git fetch origin badges:badges --depth=1
+            git worktree add /tmp/badges-wt badges
           else
-            git checkout --orphan badges
-            git rm -rf . --quiet || true
+            git worktree add --detach /tmp/badges-wt HEAD
+            git -C /tmp/badges-wt checkout --orphan badges
+            git -C /tmp/badges-wt rm -rf . --quiet 2>/dev/null || true
           fi
 
-          mv coverage.svg coverage.svg.tmp
-          git rm -rf . --quiet || true
-          mv coverage.svg.tmp coverage.svg
-
-          git add coverage.svg
-          git commit -m "ci: update coverage badge to ${TOTAL}" || echo "No changes to badge"
-          git push origin badges
+          cp /tmp/coverage.svg /tmp/badges-wt/coverage.svg
+          git -C /tmp/badges-wt add coverage.svg
+          if git -C /tmp/badges-wt diff --staged --quiet; then
+            echo "Badge unchanged, skipping commit"
+          else
+            git -C /tmp/badges-wt commit -m "chore: update coverage badge [skip ci]"
+            git -C /tmp/badges-wt push origin HEAD:badges
+          fi

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -10,9 +10,6 @@ name: reusable-coverage-report
 on:
   workflow_call:
     inputs:
-      go-version:
-        required: true
-        type: string
       pr-number:
         required: false
         type: string
@@ -29,7 +26,9 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: ${{ inputs.go-version }}
+          # Use go-version-file so the correct toolchain is installed regardless
+          # of whether .go-version and go.mod are in sync.
+          go-version-file: go.mod
 
       - name: Download coverage profiles
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/hashicorp/consul-esm.svg)](https://pkg.go.dev/github.com/hashicorp/consul-esm)
 [![build](https://github.com/hashicorp/consul-esm/actions/workflows/build.yml/badge.svg)](https://github.com/hashicorp/consul-esm/actions/workflows/build.yml)
 [![ci](https://github.com/hashicorp/consul-esm/actions/workflows/ci.yml/badge.svg)](https://github.com/hashicorp/consul-esm/actions/workflows/ci.yml)
+[![Coverage](https://raw.githubusercontent.com/hashicorp/consul-esm/badges/coverage.svg)](https://github.com/hashicorp/consul-esm/actions/workflows/ci.yml)
 
 Consul ESM (External Service Monitor)
 ================

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Codecov configuration for consul-esm.
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true   # never block PRs on coverage drop
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "**/*_test.go"
+  - "**/mocks/**"
+  - "**/mock_*"
+  - "version/**"

--- a/config.go
+++ b/config.go
@@ -225,6 +225,7 @@ type HumanConfig struct {
 	PingType flags.StringValue `mapstructure:"ping_type"`
 
 	DisableCoordinateUpdates flags.BoolValue `mapstructure:"disable_coordinate_updates"`
+	StaleReadNodes           flags.BoolValue `mapstructure:"stale_read_nodes"`
 
 	Telemetry []Telemetry `mapstructure:"telemetry"`
 
@@ -521,6 +522,7 @@ func MergeConfig(dst *Config, src *HumanConfig) error {
 	src.ClientAddress.Merge(&dst.ClientAddress)
 	src.PingType.Merge(&dst.PingType)
 	src.DisableCoordinateUpdates.Merge(&dst.DisableCoordinateUpdates)
+	src.StaleReadNodes.Merge(&dst.StaleReadNodes)
 	if len(src.Telemetry) == 1 {
 		t, err := convertTelemetry(src.Telemetry[0])
 		if err != nil {

--- a/config.go
+++ b/config.go
@@ -225,7 +225,6 @@ type HumanConfig struct {
 	PingType flags.StringValue `mapstructure:"ping_type"`
 
 	DisableCoordinateUpdates flags.BoolValue `mapstructure:"disable_coordinate_updates"`
-	StaleReadNodes           flags.BoolValue `mapstructure:"stale_read_nodes"`
 
 	Telemetry []Telemetry `mapstructure:"telemetry"`
 
@@ -522,7 +521,6 @@ func MergeConfig(dst *Config, src *HumanConfig) error {
 	src.ClientAddress.Merge(&dst.ClientAddress)
 	src.PingType.Merge(&dst.PingType)
 	src.DisableCoordinateUpdates.Merge(&dst.DisableCoordinateUpdates)
-	src.StaleReadNodes.Merge(&dst.StaleReadNodes)
 	if len(src.Telemetry) == 1 {
 		t, err := convertTelemetry(src.Telemetry[0])
 		if err != nil {


### PR DESCRIPTION
## Summary

Adds Go test coverage reporting to consul-esm, modeled after the same feature in [consul-dataplane #1083](https://github.com/hashicorp/consul-dataplane/pull/1083).

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Modified — adds `-coverprofile` to test run, uploads coverage artifact, adds `coverage-report` job |
| `.github/workflows/reusable-coverage-report.yml` | New — merges profiles, posts sticky PR comment, uploads HTML artifact, uploads to Codecov, pushes SVG badge to `badges` branch on main |
| `codecov.yml` | New — informational-only Codecov config (never blocks PRs) |
| `README.md` | Modified — adds coverage badge |


## Notes

- Consul binary install changed from apt (slow, full repo setup) to direct download from `releases.hashicorp.com` — same pattern used in other hashicorp repos
- Coverage checks are informational-only and will never block merges
- PR comment is fork-safe (guarded against read-only token on fork PRs)