### PR TITLE
fix: bind stale_read_nodes in HumanConfig and MergeConfig

### DIFF
--- a/config.go
+++ b/config.go
@@ -225,6 +225,7 @@ type HumanConfig struct {
 	PingType flags.StringValue `mapstructure:"ping_type"`
 
 	DisableCoordinateUpdates flags.BoolValue `mapstructure:"disable_coordinate_updates"`
+	StaleReadNodes           flags.BoolValue `mapstructure:"stale_read_nodes"`
 
 	Telemetry []Telemetry `mapstructure:"telemetry"`
 
@@ -521,6 +522,7 @@ func MergeConfig(dst *Config, src *HumanConfig) error {
 	src.ClientAddress.Merge(&dst.ClientAddress)
 	src.PingType.Merge(&dst.PingType)
 	src.DisableCoordinateUpdates.Merge(&dst.DisableCoordinateUpdates)
+	src.StaleReadNodes.Merge(&dst.StaleReadNodes)
 	if len(src.Telemetry) == 1 {
 		t, err := convertTelemetry(src.Telemetry[0])
 		if err != nil {


### PR DESCRIPTION
## Summary

`TestStaleReadNodesConfig` currently fails on `main`. PR #365 added the `stale_read_nodes` config field and the test, but omitted:
- the `HumanConfig` mapstructure binding for `stale_read_nodes`
- the `MergeConfig` merge call

As a result the value parsed from config never propagated to `Config.StaleReadNodes`, and the test's `can be explicitly enabled via config` / `can be disabled via config` cases fail with `invalid keys: stale_read_nodes`.

## Change
Adds the two missing lines so the config value is decoded and merged correctly.
