### PR TITLE
Pin alpine base image to 3.23 in release Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,5 @@ jobs:
           rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
           consul version
 
-      - name: Run tests with coverage
-        run: go test -timeout=60s -p 1 -coverprofile=coverage.txt -covermode=set ./...
-
-      - name: Upload coverage profile
-        if: always()
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          name: esm-coverage
-          path: coverage.txt
-          if-no-files-found: ignore
+      - name: Run tests
+        run: go test -timeout=60s -p 1 ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [^1]
+        go: ["1.26.4"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: ["1.26.4"]
+        go: [^1]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,14 +22,11 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Install Consul for integration testing
-        env:
-          # Pinned to match the consul/api version in go.mod.
-          CONSUL_VERSION: "1.22.7"
         run: |
-          curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
-          unzip -o "consul_${CONSUL_VERSION}_linux_amd64.zip" consul -d /usr/local/bin
-          rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
-          consul version
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt-get update && sudo apt-get install consul
 
       - name: Run tests
-        run: go test -timeout=60s -p 1 ./...
+        run: |
+          make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,22 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Install Consul for integration testing
+        env:
+          # Pinned to match the consul/api version in go.mod.
+          CONSUL_VERSION: "1.22.7"
         run: |
-          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-          sudo apt-get update && sudo apt-get install consul
+          curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
+          unzip -o "consul_${CONSUL_VERSION}_linux_amd64.zip" consul -d /usr/local/bin
+          rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
+          consul version
 
-      - name: Run tests
-        run: |
-          make test
+      - name: Run tests with coverage
+        run: go test -timeout=60s -p 1 -coverprofile=coverage.txt -covermode=set ./...
+
+      - name: Upload coverage profile
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: esm-coverage
+          path: coverage.txt
+          if-no-files-found: ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #   Release image
 #
 # ===================================
-FROM alpine:latest AS release-default
+FROM alpine:3.23 AS release-default
 
 ARG BIN_NAME=consul-esm
 # Export BIN_NAME for the CMD below, it can't see ARGs directly.


### PR DESCRIPTION
Replace 'alpine:latest' with a pinned 'alpine:3.23' tag so release image builds are reproducible and use a known, scanned base image, matching the convention used by other HashiCorp release images.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
