### PR TITLE
ci: gate PR merges on ≥90% patch coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,53 @@ jobs:
       id-token: write
     with:
       pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
+
+  coverage-gate:
+    name: coverage-gate
+    needs: [coverage-report]
+    runs-on: ubuntu-latest
+    env:
+      # Minimum total coverage required for the build to pass. This is a ratchet:
+      # raise it over time as coverage improves, but never set it above the current
+      # measured coverage or every PR will be blocked. Current main coverage ~67.0%.
+      COVERAGE_THRESHOLD: "65"
+    steps:
+      - name: Enforce coverage threshold
+        env:
+          TOTAL: ${{ needs.coverage-report.outputs.total }}
+        run: |
+          set -euo pipefail
+
+          echo "Measured total coverage: ${TOTAL:-<empty>}"
+          echo "Required threshold:      ${COVERAGE_THRESHOLD}%"
+
+          if [ -z "${TOTAL}" ] || [ "${TOTAL}" = "N/A" ]; then
+            echo "::error::Coverage could not be measured (no coverage profiles produced). Failing the gate."
+            {
+              echo "### ❌ Coverage gate failed"
+              echo ""
+              echo "Coverage could not be measured (no coverage profiles produced)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          PCT="${TOTAL%\%}"
+
+          if awk "BEGIN { exit !(${PCT} >= ${COVERAGE_THRESHOLD}) }"; then
+            echo "::notice::Coverage ${TOTAL} meets the ${COVERAGE_THRESHOLD}% threshold."
+            {
+              echo "### ✅ Coverage gate passed"
+              echo ""
+              echo "Total coverage **${TOTAL}** ≥ required **${COVERAGE_THRESHOLD}%**."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Coverage ${TOTAL} is below the required ${COVERAGE_THRESHOLD}% threshold."
+            {
+              echo "### ❌ Coverage gate failed"
+              echo ""
+              echo "Total coverage **${TOTAL}** is below the required **${COVERAGE_THRESHOLD}%** threshold."
+              echo ""
+              echo "Add tests to raise coverage, or adjust \`COVERAGE_THRESHOLD\` in \`.github/workflows/ci.yml\` (with reviewer sign-off)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,49 +57,56 @@ jobs:
   coverage-gate:
     name: coverage-gate
     needs: [coverage-report]
+    # Only meaningful on pull requests: patch coverage measures the lines a PR
+    # adds/modifies. Pushes to main have no "patch" to evaluate.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
-      # Minimum total coverage required for the build to pass. This is a ratchet:
-      # raise it over time as coverage improves, but never set it above the current
-      # measured coverage or every PR will be blocked. Current main coverage ~67.0%.
-      COVERAGE_THRESHOLD: "65"
+      # Minimum required coverage of the lines a PR adds/modifies (patch
+      # coverage). New/changed code must be at least this well tested.
+      PATCH_THRESHOLD: "90"
     steps:
-      - name: Enforce coverage threshold
+      - name: Enforce patch coverage threshold
         env:
-          TOTAL: ${{ needs.coverage-report.outputs.total }}
+          PATCH: ${{ needs.coverage-report.outputs.patch }}
+          COVERED: ${{ needs.coverage-report.outputs.patch_covered }}
+          COVERABLE: ${{ needs.coverage-report.outputs.patch_coverable }}
         run: |
           set -euo pipefail
 
-          echo "Measured total coverage: ${TOTAL:-<empty>}"
-          echo "Required threshold:      ${COVERAGE_THRESHOLD}%"
+          echo "Patch coverage:     ${PATCH:-<empty>}"
+          echo "Required threshold: ${PATCH_THRESHOLD}%"
+          echo "Changed lines:      ${COVERED:-0}/${COVERABLE:-0} covered"
 
-          if [ -z "${TOTAL}" ] || [ "${TOTAL}" = "N/A" ]; then
-            echo "::error::Coverage could not be measured (no coverage profiles produced). Failing the gate."
-            {
-              echo "### ❌ Coverage gate failed"
-              echo ""
-              echo "Coverage could not be measured (no coverage profiles produced)."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-          PCT="${TOTAL%\%}"
-
-          if awk "BEGIN { exit !(${PCT} >= ${COVERAGE_THRESHOLD}) }"; then
-            echo "::notice::Coverage ${TOTAL} meets the ${COVERAGE_THRESHOLD}% threshold."
+          # No coverable Go lines changed (e.g. docs-only or test-only PRs) -> nothing to gate.
+          if [ -z "${PATCH}" ] || [ "${PATCH}" = "N/A" ]; then
+            echo "::notice::No coverable Go lines changed in this PR; patch-coverage gate skipped."
             {
               echo "### ✅ Coverage gate passed"
               echo ""
-              echo "Total coverage **${TOTAL}** ≥ required **${COVERAGE_THRESHOLD}%**."
+              echo "No coverable Go lines changed in this PR, so there is nothing to gate."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          PCT="${PATCH%\%}"
+
+          if awk "BEGIN { exit !(${PCT} >= ${PATCH_THRESHOLD}) }"; then
+            echo "::notice::Patch coverage ${PATCH} meets the ${PATCH_THRESHOLD}% threshold."
+            {
+              echo "### ✅ Coverage gate passed"
+              echo ""
+              echo "Patch coverage **${PATCH}** (${COVERED}/${COVERABLE} changed lines) ≥ required **${PATCH_THRESHOLD}%**."
             } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "::error::Coverage ${TOTAL} is below the required ${COVERAGE_THRESHOLD}% threshold."
+            echo "::error::Patch coverage ${PATCH} is below the required ${PATCH_THRESHOLD}% threshold."
             {
               echo "### ❌ Coverage gate failed"
               echo ""
-              echo "Total coverage **${TOTAL}** is below the required **${COVERAGE_THRESHOLD}%** threshold."
+              echo "Patch coverage **${PATCH}** (${COVERED}/${COVERABLE} changed lines) is below the required **${PATCH_THRESHOLD}%** threshold."
               echo ""
-              echo "Add tests to raise coverage, or adjust \`COVERAGE_THRESHOLD\` in \`.github/workflows/ci.yml\` (with reviewer sign-off)."
+              echo "The lines this PR adds or modifies are not sufficiently covered by tests."
+              echo "Add tests for the new/changed code, or adjust \`PATCH_THRESHOLD\` in \`.github/workflows/ci.yml\` (with reviewer sign-off)."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,20 @@ jobs:
           echo "Changed lines:      ${COVERED:-0}/${COVERABLE:-0} covered"
 
           # No coverable Go lines changed (e.g. docs-only or test-only PRs) -> nothing to gate.
-          if [ -z "${PATCH}" ] || [ "${PATCH}" = "N/A" ]; then
+          # Fail closed: an empty PATCH means the reusable workflow could not
+          # compute patch coverage (no coverage profile produced, so the patch
+          # step was skipped). Don't let the gate pass unevaluated.
+          if [ -z "${PATCH}" ]; then
+            echo "::error::Patch coverage was not computed (no coverage profile produced). Failing closed."
+            {
+              echo "### ❌ Coverage gate failed"
+              echo ""
+              echo "Patch coverage could not be computed because no coverage profile was produced (unit tests may not have run or emitted coverage)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if [ "${PATCH}" = "N/A" ]; then
             echo "::notice::No coverable Go lines changed in this PR; patch-coverage gate skipped."
             {
               echo "### ✅ Coverage gate passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write
       id-token: write
     with:
-      pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
+      pr-number: ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.number) || '' }}
 
   coverage-gate:
     name: coverage-gate

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -13,6 +13,13 @@ on:
       pr-number:
         required: false
         type: string
+    outputs:
+      total:
+        description: >-
+          Total computed coverage as a percentage string (e.g. "67.0%"),
+          or "N/A" when no coverage profiles were found. Consumed by the
+          coverage-gate job to enforce the minimum threshold.
+        value: ${{ jobs.report.outputs.total }}
 
 jobs:
   report:
@@ -21,6 +28,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write  # required for OIDC tokenless Codecov upload
+    outputs:
+      total: ${{ steps.coverage.outputs.total }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -146,7 +146,21 @@ jobs:
                   | select(.filename | test("\\.go$"))
                   | select(.filename | test("_test\\.go$") | not)
                   | select(.filename | test("(^|/)mocks/|(^|/)mock_") | not)
-                  | "FILE\t\(.filename)\n\(.patch // "")"' > /tmp/pr-patches.txt || true
+                  | if .patch == null
+                    then "NULLPATCH\t\(.filename)"
+                    else "FILE\t\(.filename)\n\(.patch)"
+                    end' > /tmp/pr-patches.txt
+
+          # This is a merge gate, so fail closed: a coverable .go file whose
+          # diff the API cannot return (.patch == null, e.g. the file's diff is
+          # too large to render) must not be silently treated as zero changed
+          # lines and let the gate pass.
+          if grep -q '^NULLPATCH\t' /tmp/pr-patches.txt; then
+            echo "::error::Cannot compute patch coverage: the GitHub API returned no diff (patch == null) for changed Go file(s):"
+            grep '^NULLPATCH\t' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
+            echo "This usually means a single file's diff is too large for the API to render. Split the change so coverage can be measured."
+            exit 1
+          fi
 
           awk -v module="$MODULE" '
             /^FILE\t/ { file=$2; next }
@@ -154,6 +168,7 @@ jobs:
               # @@ -a,b +c,d @@  -> new-file hunk starts at line c
               plus=$3; sub(/^\+/, "", plus); split(plus, a, ","); newline=a[1]; next
             }
+            /^\\/ { next }                          # e.g. "\ No newline at end of file": not a real line
             {
               if (file=="") next
               ch=substr($0,1,1)
@@ -214,7 +229,7 @@ jobs:
           if [ -z "${PATCH:-}" ] || [ "${PATCH:-N/A}" = "N/A" ]; then
             PATCH_LINE="**Patch coverage:** N/A (no coverable Go lines changed)"
           else
-            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered, required ≥ 90%)"
+            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered)"
           fi
           BODY=$(cat <<EOF
           ${MARKER}

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -17,9 +17,22 @@ on:
       total:
         description: >-
           Total computed coverage as a percentage string (e.g. "67.0%"),
-          or "N/A" when no coverage profiles were found. Consumed by the
-          coverage-gate job to enforce the minimum threshold.
+          or "N/A" when no coverage profiles were found.
         value: ${{ jobs.report.outputs.total }}
+      patch:
+        description: >-
+          Patch coverage: the percentage of the lines this PR adds/modifies
+          (non-test, non-mock Go code) that are covered by tests. "N/A" when
+          the PR changes no coverable Go lines or coverage could not be
+          computed. Consumed by the coverage-gate job to enforce the minimum
+          patch-coverage threshold.
+        value: ${{ jobs.report.outputs.patch }}
+      patch_covered:
+        description: Number of changed coverable lines that are covered.
+        value: ${{ jobs.report.outputs.patch_covered }}
+      patch_coverable:
+        description: Number of changed coverable lines in the PR.
+        value: ${{ jobs.report.outputs.patch_coverable }}
 
 jobs:
   report:
@@ -30,6 +43,9 @@ jobs:
       id-token: write  # required for OIDC tokenless Codecov upload
     outputs:
       total: ${{ steps.coverage.outputs.total }}
+      patch: ${{ steps.patch.outputs.patch }}
+      patch_covered: ${{ steps.patch.outputs.covered }}
+      patch_coverable: ${{ steps.patch.outputs.coverable }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
@@ -109,18 +125,103 @@ jobs:
 
           go tool cover -html=merged-coverage.out -o coverage.html
 
+      - name: Compute patch coverage
+        id: patch
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pr-number }}
+          REPO: ${{ github.repository }}
+          # Go module path, used to map repo-relative diff paths to the
+          # import-path-prefixed file names used in the coverage profile.
+          MODULE: github.com/hashicorp/consul-esm
+        run: |
+          set -euo pipefail
+
+          # 1) Collect the lines this PR adds/modifies for non-test, non-mock Go
+          #    files. We read the unified diff straight from the PR via the API
+          #    (no git history needed) and emit "<module-relative-path>\t<lineno>".
+          gh api --paginate "repos/${REPO}/pulls/${PR}/files" \
+            --jq '.[]
+                  | select(.filename | test("\\.go$"))
+                  | select(.filename | test("_test\\.go$") | not)
+                  | select(.filename | test("(^|/)mocks/|(^|/)mock_") | not)
+                  | "FILE\t\(.filename)\n\(.patch // "")"' > /tmp/pr-patches.txt || true
+
+          awk -v module="$MODULE" '
+            /^FILE\t/ { file=$2; next }
+            /^@@ / {
+              # @@ -a,b +c,d @@  -> new-file hunk starts at line c
+              plus=$3; sub(/^\+/, "", plus); split(plus, a, ","); newline=a[1]; next
+            }
+            {
+              if (file=="") next
+              ch=substr($0,1,1)
+              if (ch=="+")      { print module"/"file"\t"newline; newline++ }
+              else if (ch=="-") { }                  # removed line: no new-file number
+              else              { newline++ }         # context line advances pointer
+            }
+          ' /tmp/pr-patches.txt > /tmp/changed-lines.txt
+
+          # 2) Intersect changed lines with the (already mock-filtered) coverage
+          #    profile. A changed line is "coverable" if it falls inside any
+          #    profile block, and "covered" if any such block has a hit count > 0.
+          awk '
+            BEGIN { NB = 0 }
+            FNR==NR {
+              if ($0 ~ /^mode:/) next
+              n=split($1, p, ":"); f=p[1]
+              split(p[2], rr, ","); split(rr[1], s, "."); split(rr[2], e, ".")
+              blkF[NB]=f; blkS[NB]=s[1]; blkE[NB]=e[1]; blkC[NB]=$3; NB++
+              next
+            }
+            {
+              f=$1; L=$2; coverable=0; covered=0
+              for (i=0; i<NB; i++) {
+                if (blkF[i]==f && L>=blkS[i] && L<=blkE[i]) {
+                  coverable=1; if (blkC[i]>0) covered=1
+                }
+              }
+              if (coverable) { tot++; if (covered) cov++ }
+            }
+            END {
+              if (tot==0) { print "patch=N/A"; print "covered=0"; print "coverable=0" }
+              else { printf "patch=%.1f%%\n", cov/tot*100; print "covered="cov; print "coverable="tot }
+            }
+          ' merged-coverage.out /tmp/changed-lines.txt > /tmp/patch-result.txt
+
+          PATCH=$(awk -F= '/^patch=/{print $2}' /tmp/patch-result.txt)
+          COVD=$(awk -F= '/^covered=/{print $2}' /tmp/patch-result.txt)
+          COVB=$(awk -F= '/^coverable=/{print $2}' /tmp/patch-result.txt)
+          echo "Patch coverage: ${PATCH} (${COVD}/${COVB} changed coverable lines)"
+          {
+            echo "patch=${PATCH}"
+            echo "covered=${COVD}"
+            echo "coverable=${COVB}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Post PR comment
         if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           TOTAL: ${{ steps.coverage.outputs.total }}
+          PATCH: ${{ steps.patch.outputs.patch }}
+          PATCH_COVD: ${{ steps.patch.outputs.covered }}
+          PATCH_COVB: ${{ steps.patch.outputs.coverable }}
         run: |
           MARKER="<!-- coverage-report-comment -->"
+          if [ -z "${PATCH:-}" ] || [ "${PATCH:-N/A}" = "N/A" ]; then
+            PATCH_LINE="**Patch coverage:** N/A (no coverable Go lines changed)"
+          else
+            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered, required ≥ 90%)"
+          fi
           BODY=$(cat <<EOF
           ${MARKER}
 
           ### Go Test Coverage: **${TOTAL}**
+
+          ${PATCH_LINE}
 
           See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report.
           EOF

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -155,9 +155,9 @@ jobs:
           # diff the API cannot return (.patch == null, e.g. the file's diff is
           # too large to render) must not be silently treated as zero changed
           # lines and let the gate pass.
-          if grep -q '^NULLPATCH\t' /tmp/pr-patches.txt; then
+          if grep -q '^NULLPATCH' /tmp/pr-patches.txt; then
             echo "::error::Cannot compute patch coverage: the GitHub API returned no diff (patch == null) for changed Go file(s):"
-            grep '^NULLPATCH\t' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
+            grep '^NULLPATCH' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
             echo "This usually means a single file's diff is too large for the API to render. Split the change so coverage can be measured."
             exit 1
           fi


### PR DESCRIPTION
## What

Adds a **coverage gate** that blocks a PR from merging unless **≥ 90% of the lines it adds/modifies are covered by tests** (patch coverage), not project-total coverage.

## How (deterministic, no Codecov dependency)

- `reusable-coverage-report.yml` gains a **Compute patch coverage** step that:
  - reads the PR's unified diff via the GitHub API (no git history/fetch-depth needed),
  - maps the added/modified **non-test, non-mock** Go lines to the already-merged coverage profile,
  - computes `covered`/`coverable` and the patch percentage,
  - exposes `patch`, `patch_covered`, `patch_coverable` as `workflow_call` outputs.
- `ci.yml`'s **`coverage-gate`** job (pull_request only) **fails** when patch coverage `< PATCH_THRESHOLD` (**90%**). A single, well-commented env var:
  ```yaml
  PATCH_THRESHOLD: "90"
  ```
- PRs that change **no coverable Go lines** (docs-only / test-only) pass with a clear note.
- The PR comment now also reports patch coverage (`covered/coverable`, required ≥ 90%).

## Why this design

- Consistent with our prior coverage work: **deterministic & self-contained**, so it is not subject to Codecov external-service / fork-token flakiness. `codecov.yml` stays `informational` — this gate is the single source of truth.
- **Patch coverage** (not project total) is the right merge gate: it enforces that *new* code is tested without retroactively blocking PRs over legacy untested code.

## One-time follow-up (admin)

To actually block merges, add **`coverage-gate`** as a **required status check** in branch protection for `main`.

## Validation

- Both workflows YAML-validated.
- Both awk scripts (diff parser + profile intersection) were extracted from the committed file and unit-tested end-to-end: a synthetic PR touching covered + uncovered lines yields the expected `75.0% (3/4)`; a fixed off-by-one array-init bug (`NB` defaulting to `""` dropped the first block) was caught and corrected.
- Gate threshold dry-run: `90.0% → PASS`, `89.9% → FAIL`.