### PR TITLE
fix: do not hang computeWatchedNodes when watchers stop without sending

### DIFF
--- a/leader.go
+++ b/leader.go
@@ -155,8 +155,21 @@ func (a *Agent) computeWatchedNodes(stopCh <-chan struct{}) {
 	go a.watchExternalNodes(nodeCh, stopCh)
 	go a.watchServiceInstances(instanceCh, stopCh)
 
-	externalNodes := <-nodeCh
-	healthyInstances := <-instanceCh
+	// The watchers can return without sending if their first Consul query
+	// errors and stopCh is then closed. Select on stopCh so we don't block
+	// forever on those initial receives.
+	var externalNodes []*api.Node
+	select {
+	case <-stopCh:
+		return
+	case externalNodes = <-nodeCh:
+	}
+	var healthyInstances []*api.ServiceEntry
+	select {
+	case <-stopCh:
+		return
+	case healthyInstances = <-instanceCh:
+	}
 
 	metrics.SetGauge([]string{"esm", "agents", "healthy"}, float32(len(healthyInstances)))
 
@@ -282,7 +295,11 @@ func (a *Agent) watchExternalNodes(nodeCh chan []*api.Node, stopCh <-chan struct
 
 		a.logger.Info("Updating external node list", "items", len(externalNodes))
 
-		nodeCh <- externalNodes
+		select {
+		case <-stopCh:
+			return
+		case nodeCh <- externalNodes:
+		}
 	}
 }
 
@@ -313,7 +330,11 @@ func (a *Agent) watchServiceInstances(instanceCh chan []*api.ServiceEntry, stopC
 
 		switch healthyInstances, err := a.getServiceInstances(opts); err {
 		case nil:
-			instanceCh <- healthyInstances
+			select {
+			case <-stopCh:
+				return
+			case instanceCh <- healthyInstances:
+			}
 		default:
 			a.logger.Warn("[WARN] Error querying for health check info",
 				"error", err)

--- a/leader_test.go
+++ b/leader_test.go
@@ -573,3 +573,117 @@ func TestLeader_isLeaderMetric(t *testing.T) {
 		r.Fatalf("did not find the key %q in any of the %d intervals", isLeaderKey, len(intervals))
 	})
 }
+
+// testAgentWithoutRun builds an Agent that talks to addr without starting Run().
+func testAgentWithoutRun(t *testing.T, addr string) *Agent {
+	t.Helper()
+	client, err := api.NewClient(&api.Config{Address: addr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conf, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Agent{
+		config:     conf,
+		client:     client,
+		logger:     hclog.NewNullLogger(),
+		shutdownCh: make(chan struct{}),
+	}
+}
+
+func TestComputeWatchedNodes_doesNotBlockWhenCatalogErrorsThenStopped(t *testing.T) {
+	t.Parallel()
+
+	catalogCalls := make(chan struct{}, 8)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v1/catalog/nodes") {
+			select {
+			case catalogCalls <- struct{}{}:
+			default:
+			}
+			http.Error(w, "catalog unavailable", http.StatusInternalServerError)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/v1/health/service/") {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, "[]")
+			return
+		}
+		http.Error(w, "unexpected", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	agent := testAgentWithoutRun(t, ts.URL)
+
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		agent.computeWatchedNodes(stopCh)
+	}()
+
+	// First catalog query fails on the firstRun path (no stopCh check yet).
+	select {
+	case <-catalogCalls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for catalog query")
+	}
+
+	close(stopCh)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("computeWatchedNodes blocked on nodeCh after catalog error and stop")
+	}
+}
+
+func TestComputeWatchedNodes_doesNotBlockWhenInstancesNeverArriveThenStopped(t *testing.T) {
+	t.Parallel()
+
+	catalogCalls := make(chan struct{}, 8)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v1/catalog/nodes") {
+			select {
+			case catalogCalls <- struct{}{}:
+			default:
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Consul-Index", "1")
+			fmt.Fprint(w, "[]")
+			return
+		}
+		if strings.Contains(r.URL.Path, "/v1/health/service/") {
+			http.Error(w, "health unavailable", http.StatusInternalServerError)
+			return
+		}
+		http.Error(w, "unexpected", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	agent := testAgentWithoutRun(t, ts.URL)
+
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		agent.computeWatchedNodes(stopCh)
+	}()
+
+	// Catalog succeeds and is sent on nodeCh; instance watch errors and never sends.
+	select {
+	case <-catalogCalls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for catalog query")
+	}
+
+	close(stopCh)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("computeWatchedNodes blocked on instanceCh after stop")
+	}
+}


### PR DESCRIPTION
## Summary
If `watchExternalNodes` hits a first-query error and then `stopCh` closes, it returned without sending on the unbuffered `nodeCh`, so `computeWatchedNodes` blocked forever on the initial receive (same shape for `instanceCh` when health queries never succeed). Select on `stopCh` for those initial receives and for watcher sends.

Fixes #301

## Test plan
- [x] `go test -timeout=15s -count=1 -run 'TestComputeWatchedNodes_doesNotBlock' .`
- [x] Catalog-error-then-stop returns promptly
- [x] Instance-channel never-arrives-then-stop returns promptly